### PR TITLE
Fix #154: Exclude ehcache Spring WS security dependency

### DIFF
--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -60,6 +60,16 @@
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>ehcache</artifactId>
+                    <groupId>net.sf.ehcache</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                    <groupId>org.apache.geronimo.javamail</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Exclude geronimo-javamail because of issues found in OWASP report