### PR TITLE
Use ephemeralPublicKey instead of ephemeralKey

### DIFF
--- a/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
@@ -953,7 +953,7 @@ public class PowerAuthServiceClient {
         request.setApplicationKey(applicationKey);
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
-        request.setEphemeralKey(ephemeralPublicKey);
+        request.setEphemeralPublicKey(ephemeralPublicKey);
         request.setSignatureType(signatureType);
         return createToken(request);
     }
@@ -1005,7 +1005,7 @@ public class PowerAuthServiceClient {
         PowerAuthPortV3ServiceStub.GetEciesDecryptorRequest request = new PowerAuthPortV3ServiceStub.GetEciesDecryptorRequest();
         request.setActivationId(activationId);
         request.setApplicationKey(applicationKey);
-        request.setEphemeralKey(ephemeralPublicKey);
+        request.setEphemeralPublicKey(ephemeralPublicKey);
         return getEciesDecryptor(request);
     }
 

--- a/powerauth-java-client-axis/src/main/resources/soap/wsdl/service-v3.wsdl
+++ b/powerauth-java-client-axis/src/main/resources/soap/wsdl/service-v3.wsdl
@@ -316,7 +316,7 @@
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationCode" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>
@@ -348,7 +348,7 @@
                         <xs:element maxOccurs="1" minOccurs="0" name="timestampActivationExpire" type="xs:dateTime"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="maxFailureCount" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>
@@ -683,7 +683,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="signedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signature" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signatureType" type="tns:SignatureType"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>
@@ -989,7 +989,7 @@
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationId" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signatureType" type="tns:SignatureType"/>
@@ -1069,10 +1069,10 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <!-- activationId is optional -->
-                        <xs:element name="activationId" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                        <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                        <!--  activationId is optional  -->
+                        <xs:element maxOccurs="1" minOccurs="0" name="activationId" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1083,11 +1083,12 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="secretKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                        <xs:element name="sharedInfo2" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="secretKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="sharedInfo2" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+
             <!-- Migration to version 3.0 //-->
 
             <xs:element name="MigrationStartRequest">
@@ -1098,7 +1099,7 @@
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationId" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>

--- a/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
@@ -799,7 +799,7 @@ public class PowerAuthServiceClient extends WebServiceGatewaySupport {
         request.setApplicationKey(applicationKey);
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
-        request.setEphemeralKey(ephemeralPublicKey);
+        request.setEphemeralPublicKey(ephemeralPublicKey);
         request.setSignatureType(signatureType);
         return createToken(request);
     }
@@ -872,7 +872,7 @@ public class PowerAuthServiceClient extends WebServiceGatewaySupport {
         GetEciesDecryptorRequest request = new GetEciesDecryptorRequest();
         request.setActivationId(activationId);
         request.setApplicationKey(applicationKey);
-        request.setEphemeralKey(ephemeralPublicKey);
+        request.setEphemeralPublicKey(ephemeralPublicKey);
         return getEciesDecryptor(request);
     }
 

--- a/powerauth-java-client-spring/src/main/resources/soap/wsdl/service-v3.wsdl
+++ b/powerauth-java-client-spring/src/main/resources/soap/wsdl/service-v3.wsdl
@@ -316,7 +316,7 @@
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationCode" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>
@@ -348,7 +348,7 @@
                         <xs:element maxOccurs="1" minOccurs="0" name="timestampActivationExpire" type="xs:dateTime"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="maxFailureCount" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>
@@ -683,7 +683,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="signedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signature" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signatureType" type="tns:SignatureType"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>
@@ -989,7 +989,7 @@
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationId" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signatureType" type="tns:SignatureType"/>
@@ -1069,10 +1069,10 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <!-- activationId is optional -->
-                        <xs:element name="activationId" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                        <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                        <!--  activationId is optional  -->
+                        <xs:element maxOccurs="1" minOccurs="0" name="activationId" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1083,8 +1083,8 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="secretKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                        <xs:element name="sharedInfo2" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="secretKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="sharedInfo2" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1099,7 +1099,7 @@
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationId" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationKey" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="ephemeralPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="encryptedData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="mac" type="xs:string"/>
                     </xs:sequence>

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/EciesEncryptionBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/EciesEncryptionBehavior.java
@@ -110,7 +110,7 @@ public class EciesEncryptionBehavior {
      * @throws GenericServiceException In case ECIES decryptor parameters could not be extracted.
      */
     private GetEciesDecryptorResponse getEciesDecryptorParametersForApplication(GetEciesDecryptorRequest request) throws GenericServiceException {
-        if (request.getApplicationKey() == null || request.getEphemeralKey() == null) {
+        if (request.getApplicationKey() == null || request.getEphemeralPublicKey() == null) {
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
         }
 
@@ -139,7 +139,7 @@ public class EciesEncryptionBehavior {
             final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForApplication((ECPrivateKey) privateKey, applicationSecret);
 
             // Initialize decryptor with ephemeral public key
-            byte[] ephemeralPublicKeyBytes = BaseEncoding.base64().decode(request.getEphemeralKey());
+            byte[] ephemeralPublicKeyBytes = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
             decryptor.initEnvelopeKey(ephemeralPublicKeyBytes);
 
             // Extract envelope key and sharedInfo2 parameters to allow decryption on intermediate server
@@ -162,7 +162,7 @@ public class EciesEncryptionBehavior {
      * @throws GenericServiceException In case ECIES decryptor parameters could not be extracted.
      */
     private GetEciesDecryptorResponse getEciesDecryptorParametersForActivation(GetEciesDecryptorRequest request) throws GenericServiceException {
-        if (request.getApplicationKey() == null || request.getEphemeralKey() == null) {
+        if (request.getApplicationKey() == null || request.getEphemeralPublicKey() == null) {
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
         }
 
@@ -210,7 +210,7 @@ public class EciesEncryptionBehavior {
             final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForActivation((ECPrivateKey) privateKey, applicationSecret, transportKey, EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC);
 
             // Initialize decryptor with ephemeral public key
-            byte[] ephemeralPublicKeyBytes = BaseEncoding.base64().decode(request.getEphemeralKey());
+            byte[] ephemeralPublicKeyBytes = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
             decryptor.initEnvelopeKey(ephemeralPublicKeyBytes);
 
             // Extract envelope key and sharedInfo2 parameters to allow decryption on intermediate server

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
@@ -100,7 +100,7 @@ public class TokenBehavior {
     public CreateTokenResponse createToken(CreateTokenRequest request, CryptoProviderUtil keyConversion) throws GenericServiceException {
         final String activationId = request.getActivationId();
         final String applicationKey = request.getApplicationKey();
-        final byte[] ephemeralPublicKey = BaseEncoding.base64().decode(request.getEphemeralKey());
+        final byte[] ephemeralPublicKey = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
         final byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
         final byte[] mac = BaseEncoding.base64().decode(request.getMac());
         final SignatureType signatureType = request.getSignatureType();

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -317,7 +317,7 @@
             <xs:sequence>
                 <xs:element name="activationCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="encryptedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="mac" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
@@ -349,7 +349,7 @@
                 <xs:element name="timestampActivationExpire" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="maxFailureCount" type="xs:long" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="encryptedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="mac" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
@@ -685,7 +685,7 @@
                 <xs:element name="signedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="signature" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="signatureType" type="tns:SignatureType" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="encryptedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="mac" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
@@ -991,7 +991,7 @@
             <xs:sequence>
                 <xs:element name="activationId" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="encryptedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="mac" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="signatureType" type="tns:SignatureType" minOccurs="1" maxOccurs="1"/>
@@ -1074,7 +1074,7 @@
                 <!-- activationId is optional -->
                 <xs:element name="activationId" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -1101,7 +1101,7 @@
             <xs:sequence>
                 <xs:element name="activationId" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="ephemeralKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="encryptedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="mac" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>


### PR DESCRIPTION
As agreed with @hvge, `ephemeralPublicKey` will be used instead of `ephemeralKey` in SOAP interfaces.