### PR TITLE
Fix #192: Crypto 3.0: Activation code should not be required in database

### DIFF
--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE `pa_master_keypair` (
 
 CREATE TABLE `pa_activation` (
   `activation_id` varchar(37) NOT NULL,
-  `activation_code` varchar(255) NOT NULL,
+  `activation_code` varchar(255),
   `activation_status` int(11) NOT NULL,
   `blocked_reason` varchar(255) DEFAULT NULL,
   `activation_name` varchar(255) DEFAULT NULL,

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE "PA_ACTIVATION"
     "APPLICATION_ID"                NUMBER(19,0) NOT NULL,
     "USER_ID"                       VARCHAR2(255 CHAR) NOT NULL,
     "ACTIVATION_NAME"               VARCHAR2(255 CHAR),
-    "ACTIVATION_CODE"               VARCHAR2(255 CHAR) NOT NULL,
+    "ACTIVATION_CODE"               VARCHAR2(255 CHAR),
     "ACTIVATION_STATUS"             NUMBER(10,0) NOT NULL,
     "BLOCKED_REASON"                VARCHAR2(255 CHAR),
     "COUNTER"                       NUMBER(19,0) NOT NULL,

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE "pa_activation"
     "application_id"                INTEGER NOT NULL,
     "user_id"                       VARCHAR(255) NOT NULL,
     "activation_name"               VARCHAR(255),
-    "activation_code"               VARCHAR(255) NOT NULL,
+    "activation_code"               VARCHAR(255),
     "activation_status"             INTEGER NOT NULL,
     "blocked_reason"                VARCHAR(255),
     "counter"                       INTEGER NOT NULL,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -64,6 +64,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -591,7 +592,7 @@ public class ActivationServiceBehavior {
         }
 
         // Get application secret
-        byte[] applicationSecret = BaseEncoding.base64().decode(applicationVersion.getApplicationSecret());
+        byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
 
         // Get ecies decryptor
         EciesDecryptor eciesDecryptor = eciesFactory.getEciesDecryptorForApplication((ECPrivateKey) privateKey, applicationSecret, EciesSharedInfo1.ACTIVATION_LAYER_2);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/EciesEncryptionBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/EciesEncryptionBehavior.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
@@ -133,7 +134,7 @@ public class EciesEncryptionBehavior {
             }
 
             // Get application secret
-            final byte[] applicationSecret = BaseEncoding.base64().decode(applicationVersion.getApplicationSecret());
+            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
 
             // Get decryptor for the application
             final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForApplication((ECPrivateKey) privateKey, applicationSecret, EciesSharedInfo1.APPLICATION_SCOPE_GENERIC);
@@ -202,7 +203,7 @@ public class EciesEncryptionBehavior {
             }
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
-            final byte[] applicationSecret = BaseEncoding.base64().decode(applicationVersion.getApplicationSecret());
+            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
             final byte[] devicePublicKey = BaseEncoding.base64().decode(activation.getDevicePublicKeyBase64());
             final byte[] transportKey = keyDerivationUtil.deriveTransportKey(serverPrivateKey, devicePublicKey);
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
@@ -47,6 +47,7 @@ import io.getlime.security.powerauth.v3.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
@@ -144,16 +145,16 @@ public class TokenBehavior {
             final String serverPrivateKeyFromEntity = activation.getServerPrivateKeyBase64();
             final KeyEncryptionMode serverPrivateKeyEncryptionMode = activation.getServerPrivateKeyEncryption();
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity, activation.getUserId(), activation.getActivationId());
-            final byte[] serverPrivateKey = BaseEncoding.base64().decode(serverPrivateKeyBase64);
+            byte[] serverPrivateKey = BaseEncoding.base64().decode(serverPrivateKeyBase64);
 
             // KEY_SERVER_PRIVATE is used in Crypto version 3.0 for ECIES, note that in version 2.0 KEY_SERVER_MASTER_PRIVATE is used
             final PrivateKey privateKey = keyConversion.convertBytesToPrivateKey(serverPrivateKey);
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
             final ApplicationVersionEntity applicationVersion = repositoryCatalogue.getApplicationVersionRepository().findByApplicationKey(applicationKey);
-            final byte[] applicationSecret = BaseEncoding.base64().decode(applicationVersion.getApplicationSecret());
-            final byte[] devicePublicKey = BaseEncoding.base64().decode(activation.getDevicePublicKeyBase64());
-            final byte[] transportKey = keyDerivationUtil.deriveTransportKey(serverPrivateKey, devicePublicKey);
+            byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+            byte[] devicePublicKey = BaseEncoding.base64().decode(activation.getDevicePublicKeyBase64());
+            byte[] transportKey = keyDerivationUtil.deriveTransportKey(serverPrivateKey, devicePublicKey);
 
             // Get decryptor for the activation
             final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForActivation((ECPrivateKey) privateKey,


### PR DESCRIPTION
Fix of two minor issues:
- #192: Crypto 3.0: Activation code should not be required in database
- #194: Crypto 3.0: Use application secret for ECIES in Base64 form #194