### PR TITLE
Fix #198: Crypto 3.0: Improve error handling and input validation based on automated test results

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
@@ -441,6 +441,19 @@ public class ActivationServiceBehavior {
         return response;
     }
 
+    /**
+     * Init activation with given parameters
+     *
+     * @param applicationId             Application ID
+     * @param userId                    User ID
+     * @param maxFailedCount            Maximum failed attempt count (5)
+     * @param activationExpireTimestamp Timestamp after which activation can no longer be completed
+     * @param keyConversionUtilities    Utility class for key conversion
+     * @return Response with activation initialization data
+     * @throws GenericServiceException If invalid values are provided.
+     * @throws InvalidKeySpecException If invalid key is provided
+     * @throws InvalidKeyException     If invalid key is provided
+     */
     private String initActivation(Long applicationId, String userId, Long maxFailedCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException {
         // Generate timestamp in advance
         Date timestamp = new Date();
@@ -452,6 +465,8 @@ public class ActivationServiceBehavior {
         if (applicationId == 0L) {
             throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
         }
+
+        // Application version is not being checked in initActivation, it is checked later in prepareActivation or createActivation.
 
         // Get the repository
         final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -430,6 +430,8 @@ public class ActivationServiceBehavior {
             throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
         }
 
+        // Application version is not being checked in initActivation, it is checked later in prepareActivation or createActivation.
+
         // Get the repository
         final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
         final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
@@ -224,7 +224,9 @@ public class TokenBehavior {
         // Lookup the token.
         final Optional<TokenEntity> tokenEntityOptional = repositoryCatalogue.getTokenRepository().findById(tokenId);
         if (!tokenEntityOptional.isPresent()) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_TOKEN);
+            final ValidateTokenResponse response = new ValidateTokenResponse();
+            response.setTokenValid(false);
+            return response;
         }
         final TokenEntity token = tokenEntityOptional.get();
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/VaultUnlockServiceBehavior.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.app.server.service.behavior.ServiceBehavior
 import io.getlime.security.powerauth.app.server.service.behavior.util.KeyDerivationUtil;
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.request.VaultUnlockRequestPayload;
 import io.getlime.security.powerauth.app.server.service.model.response.VaultUnlockResponsePayload;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
@@ -170,6 +171,10 @@ public class VaultUnlockServiceBehavior {
         }
 
         String reason = request.getReason();
+
+        if (reason != null && reason.length() > 255) {
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+        }
 
         // Save vault unlock reason into additional info which is logged in signature audit log.
         // If value unlock reason is missing, use default NOT_SPECIFIED value.

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v2/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v2/PowerAuthServiceImpl.java
@@ -169,6 +169,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_SIGNATURE);
             }
 
+            if (reason != null && reason.length() > 255) {
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+            }
+
             // Save vault unlock reason into additional info which is logged in signature audit log.
             // If value unlock reason is missing, use default NOT_SPECIFIED value.
             KeyValueMap additionalInfo = new KeyValueMap();


### PR DESCRIPTION
Following issues were found by automated tests:
- NPE in `verifyECDSASignature`
- 500 error when removed token was validated (we should rather return token not valid response)
- database error when vault unlock reason was too long
- application version is not checked in `initActivation` (this is OK, I just added a comment it is checked later)