### PR TITLE
Fix #208: Crypto 3.0: Handle new exceptions from powerauth-crypto

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
@@ -37,8 +37,10 @@ import io.getlime.security.powerauth.app.server.service.exceptions.GenericServic
 import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import io.getlime.security.powerauth.v2.CreateActivationResponse;
 import io.getlime.security.powerauth.v2.PrepareActivationResponse;
 import org.slf4j.Logger;
@@ -46,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -131,21 +132,19 @@ public class ActivationServiceBehavior {
     }
 
     /**
-     * Validate provided public key and if the key is null, remove provided activation
-     * (mark as REMOVED), notify callback listeners, and throw exception.
+     * Handle case when public key is invalid. Remove provided activation (mark as REMOVED),
+     * notify callback listeners, and throw an exception.
      *
-     * @param activation Activation to be removed in case the device public key is not valid.
-     * @param devicePublicKey Device public key to be checked.
-     * @throws GenericServiceException In case provided public key is null.
+     * @param activation Activation to be removed.
+     * @throws GenericServiceException Error caused by invalid public key.
      */
-    private void validateNotNullPublicKey(ActivationRecordEntity activation, PublicKey devicePublicKey) throws GenericServiceException {
-        if (devicePublicKey == null) { // invalid key was sent, return error
-            activation.setActivationStatus(ActivationStatus.REMOVED);
-            repositoryCatalogue.getActivationRepository().save(activation);
-            activationHistoryServiceBehavior.logActivationStatusChange(activation);
-            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
-        }
+    private void handleInvalidPublicKey(ActivationRecordEntity activation) throws GenericServiceException {
+        activation.setActivationStatus(ActivationStatus.REMOVED);
+        repositoryCatalogue.getActivationRepository().save(activation);
+        activationHistoryServiceBehavior.logActivationStatusChange(activation);
+        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+        logger.warn("Invalid public key, activation ID: {}", activation.getActivationId());
+        throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
     }
 
     /**
@@ -161,11 +160,13 @@ public class ActivationServiceBehavior {
         if (activation == null
                 || !ActivationStatus.CREATED.equals(activation.getActivationStatus())
                 || !Objects.equals(activation.getApplication().getId(), application.getId())) {
+            logger.info("Activation is expired, activation ID: {}", activation != null ? activation.getActivationId() : "unknown");
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
         }
 
         // Make sure activation code has 23 characters
         if (activation.getActivationCode().length() != 23) {
+            logger.warn("Activation code is invalid, activation ID: {}", activation.getActivationId());
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
         }
     }
@@ -183,124 +184,138 @@ public class ActivationServiceBehavior {
      * @param applicationSignature           Application signature
      * @param keyConversionUtilities         Utility class for key conversion
      * @return Prepared activation information
-     * @throws GenericServiceException      In case invalid data is provided
-     * @throws InvalidKeySpecException      If invalid key was provided
-     * @throws InvalidKeyException          If invalid key was provided
-     * @throws UnsupportedEncodingException If UTF-8 is not supported on the system
+     * @throws GenericServiceException      In case prepare activation fails
      */
-    public PrepareActivationResponse prepareActivation(String activationIdShort, String activationNonceBase64, String clientEphemeralPublicKeyBase64, String cDevicePublicKeyBase64, String activationName, String extras, String applicationKey, String applicationSignature, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException, UnsupportedEncodingException {
+    public PrepareActivationResponse prepareActivation(String activationIdShort, String activationNonceBase64, String clientEphemeralPublicKeyBase64, String cDevicePublicKeyBase64, String activationName, String extras, String applicationKey, String applicationSignature, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
+        try {
+            // Get current timestamp
+            Date timestamp = new Date();
 
-        // Get current timestamp
-        Date timestamp = new Date();
+            // Get the repository
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+            final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
 
-        // Get the repository
-        final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
-        final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
+            ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
+            // if there is no such application, exit
+            if (applicationVersion == null || !applicationVersion.getSupported()) {
+                logger.warn("Application version is incorrect, application key: {}", applicationKey);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
 
-        ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-        // if there is no such application, exit
-        if (applicationVersion == null || !applicationVersion.getSupported()) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            ApplicationEntity application = applicationVersion.getApplication();
+            // if there is no such application, exit
+            if (application == null) {
+                logger.warn("Application does not exist, application key: {}", applicationKey);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+
+            // Fetch the current activation by short activation ID
+            Set<ActivationStatus> states = ImmutableSet.of(ActivationStatus.CREATED);
+            ActivationRecordEntity activation = activationRepository.findCreatedActivationWithShortId(application.getId(), activationIdShort, states, timestamp);
+
+            // Make sure to deactivate the activation if it is expired
+            if (activation != null) {
+                deactivatePendingActivation(timestamp, activation);
+            }
+
+            // Validate that the activation is in correct state for the prepare step
+            validateActivationInPrepareStep(activation, application);
+
+            // Extract activation OTP from activation code
+            String activationOtp = activation.getActivationCode().substring(12);
+
+            // Get master private key
+            String masterPrivateKeyBase64 = activation.getMasterKeyPair().getMasterKeyPrivateBase64();
+            byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
+            PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
+
+            // Get client ephemeral public key
+            PublicKey clientEphemeralPublicKey = null;
+            if (clientEphemeralPublicKeyBase64 != null) { // additional encryption is used
+                byte[] clientEphemeralPublicKeyBytes = BaseEncoding.base64().decode(clientEphemeralPublicKeyBase64);
+                clientEphemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(clientEphemeralPublicKeyBytes);
+            }
+
+            // Decrypt the device public key
+            byte[] C_devicePublicKey = BaseEncoding.base64().decode(cDevicePublicKeyBase64);
+            byte[] activationNonce = BaseEncoding.base64().decode(activationNonceBase64);
+
+            PublicKey devicePublicKey = null;
+            try {
+                devicePublicKey = powerAuthServerActivation.decryptDevicePublicKey(
+                        C_devicePublicKey,
+                        activationIdShort,
+                        masterPrivateKey,
+                        clientEphemeralPublicKey,
+                        activationOtp,
+                        activationNonce
+                );
+            } catch (GenericCryptoException ex) {
+                handleInvalidPublicKey(activation);
+            }
+
+            byte[] applicationSignatureBytes = BaseEncoding.base64().decode(applicationSignature);
+
+            if (!powerAuthServerActivation.validateApplicationSignature(
+                    activationIdShort,
+                    activationNonce,
+                    C_devicePublicKey,
+                    BaseEncoding.base64().decode(applicationKey),
+                    BaseEncoding.base64().decode(applicationVersion.getApplicationSecret()),
+                    applicationSignatureBytes)) {
+                logger.warn("Activation signature is invalid, activation ID short: {}", activationIdShort);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+
+            // Update and persist the activation record
+            activation.setActivationStatus(ActivationStatus.OTP_USED);
+            activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setActivationName(activationName);
+            activation.setExtras(extras);
+            // PowerAuth protocol version 2.0 and 2.1 uses 0x2 as version in activation status
+            activation.setVersion(2);
+            // Counter data is null, numeric counter is used in this version
+            activationRepository.save(activation);
+            activationHistoryServiceBehavior.logActivationStatusChange(activation);
+            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+
+            // Generate response data
+            byte[] activationNonceServer = powerAuthServerActivation.generateActivationNonce();
+            String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
+            PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
+            KeyPair ephemeralKeyPair = new KeyGenerator().generateKeyPair();
+            PrivateKey ephemeralPrivateKey = ephemeralKeyPair.getPrivate();
+            PublicKey ephemeralPublicKey = ephemeralKeyPair.getPublic();
+            byte[] ephemeralPublicKeyBytes = keyConversionUtilities.convertPublicKeyToBytes(ephemeralPublicKey);
+
+            // Encrypt the public key
+            byte[] C_serverPublicKey = powerAuthServerActivation.encryptServerPublicKey(serverPublicKey, devicePublicKey, ephemeralPrivateKey, activationOtp, activationIdShort, activationNonceServer);
+
+            // Get encrypted public key signature
+            byte[] C_serverPubKeySignature = powerAuthServerActivation.computeServerDataSignature(activation.getActivationId(), C_serverPublicKey, masterPrivateKey);
+            if (C_serverPubKeySignature == null) { // in case there is a technical error with signing and null is returned, return random bytes
+                C_serverPubKeySignature = new KeyGenerator().generateRandomBytes(71);
+            }
+
+            // Compute the response
+            PrepareActivationResponse response = new PrepareActivationResponse();
+            response.setActivationId(activation.getActivationId());
+            response.setActivationNonce(BaseEncoding.base64().encode(activationNonceServer));
+            response.setEncryptedServerPublicKey(BaseEncoding.base64().encode(C_serverPublicKey));
+            response.setEncryptedServerPublicKeySignature(BaseEncoding.base64().encode(C_serverPubKeySignature));
+            response.setEphemeralPublicKey(BaseEncoding.base64().encode(ephemeralPublicKeyBytes));
+
+            return response;
+        } catch (InvalidKeySpecException | InvalidKeyException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
-
-        ApplicationEntity application = applicationVersion.getApplication();
-        // if there is no such application, exit
-        if (application == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-
-        // Fetch the current activation by short activation ID
-        Set<ActivationStatus> states = ImmutableSet.of(ActivationStatus.CREATED);
-        ActivationRecordEntity activation = activationRepository.findCreatedActivationWithShortId(application.getId(), activationIdShort, states, timestamp);
-
-        // Make sure to deactivate the activation if it is expired
-        if (activation != null) {
-            deactivatePendingActivation(timestamp, activation);
-        }
-
-        // Validate that the activation is in correct state for the prepare step
-        validateActivationInPrepareStep(activation, application);
-
-        // Extract activation OTP from activation code
-        String activationOtp = activation.getActivationCode().substring(12);
-
-        // Get master private key
-        String masterPrivateKeyBase64 = activation.getMasterKeyPair().getMasterKeyPrivateBase64();
-        byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
-        PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
-
-        // Get client ephemeral public key
-        PublicKey clientEphemeralPublicKey = null;
-        if (clientEphemeralPublicKeyBase64 != null) { // additional encryption is used
-            byte[] clientEphemeralPublicKeyBytes = BaseEncoding.base64().decode(clientEphemeralPublicKeyBase64);
-            clientEphemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(clientEphemeralPublicKeyBytes);
-        }
-
-        // Decrypt the device public key
-        byte[] C_devicePublicKey = BaseEncoding.base64().decode(cDevicePublicKeyBase64);
-        byte[] activationNonce = BaseEncoding.base64().decode(activationNonceBase64);
-        PublicKey devicePublicKey = powerAuthServerActivation.decryptDevicePublicKey(
-                C_devicePublicKey,
-                activationIdShort,
-                masterPrivateKey,
-                clientEphemeralPublicKey,
-                activationOtp,
-                activationNonce
-        );
-
-        validateNotNullPublicKey(activation, devicePublicKey);
-
-        byte[] applicationSignatureBytes = BaseEncoding.base64().decode(applicationSignature);
-
-        if (!powerAuthServerActivation.validateApplicationSignature(
-                activationIdShort,
-                activationNonce,
-                C_devicePublicKey,
-                BaseEncoding.base64().decode(applicationKey),
-                BaseEncoding.base64().decode(applicationVersion.getApplicationSecret()),
-                applicationSignatureBytes)) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-
-        // Update and persist the activation record
-        activation.setActivationStatus(ActivationStatus.OTP_USED);
-        activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
-        activation.setActivationName(activationName);
-        activation.setExtras(extras);
-        // PowerAuth protocol version 2.0 and 2.1 uses 0x2 as version in activation status
-        activation.setVersion(2);
-        // Counter data is null, numeric counter is used in this version
-        activationRepository.save(activation);
-        activationHistoryServiceBehavior.logActivationStatusChange(activation);
-        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-
-        // Generate response data
-        byte[] activationNonceServer = powerAuthServerActivation.generateActivationNonce();
-        String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
-        PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
-        KeyPair ephemeralKeyPair = new KeyGenerator().generateKeyPair();
-        PrivateKey ephemeralPrivateKey = ephemeralKeyPair.getPrivate();
-        PublicKey ephemeralPublicKey = ephemeralKeyPair.getPublic();
-        byte[] ephemeralPublicKeyBytes = keyConversionUtilities.convertPublicKeyToBytes(ephemeralPublicKey);
-
-        // Encrypt the public key
-        byte[] C_serverPublicKey = powerAuthServerActivation.encryptServerPublicKey(serverPublicKey, devicePublicKey, ephemeralPrivateKey, activationOtp, activationIdShort, activationNonceServer);
-
-        // Get encrypted public key signature
-        byte[] C_serverPubKeySignature = powerAuthServerActivation.computeServerDataSignature(activation.getActivationId(), C_serverPublicKey, masterPrivateKey);
-        if (C_serverPubKeySignature == null) { // in case there is a technical error with signing and null is returned, return random bytes
-            C_serverPubKeySignature = new KeyGenerator().generateRandomBytes(71);
-        }
-
-        // Compute the response
-        PrepareActivationResponse response = new PrepareActivationResponse();
-        response.setActivationId(activation.getActivationId());
-        response.setActivationNonce(BaseEncoding.base64().encode(activationNonceServer));
-        response.setEncryptedServerPublicKey(BaseEncoding.base64().encode(C_serverPublicKey));
-        response.setEncryptedServerPublicKeySignature(BaseEncoding.base64().encode(C_serverPubKeySignature));
-        response.setEphemeralPublicKey(BaseEncoding.base64().encode(ephemeralPublicKeyBytes));
-
-        return response;
     }
 
     /**
@@ -320,10 +335,7 @@ public class ActivationServiceBehavior {
      * @param applicationSignature           Application signature
      * @param keyConversionUtilities         Utility class for key conversion
      * @return Prepared activation information
-     * @throws GenericServiceException      In case invalid data is provided
-     * @throws InvalidKeySpecException      If invalid key was provided
-     * @throws InvalidKeyException          If invalid key was provided
-     * @throws UnsupportedEncodingException If UTF-8 is not supported on the system
+     * @throws GenericServiceException      In case create activation fails
      */
     public CreateActivationResponse createActivation(
             String applicationKey,
@@ -338,106 +350,124 @@ public class ActivationServiceBehavior {
             String activationName,
             String extras,
             String applicationSignature,
-            CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException, UnsupportedEncodingException {
+            CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
+        try {
 
-        // Get the repository
-        final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
-        final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
+            // Get the repository
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+            final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
 
-        ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-        // if there is no such application, exit
-        if (applicationVersion == null || !applicationVersion.getSupported()) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
+            // if there is no such application, exit
+            if (applicationVersion == null || !applicationVersion.getSupported()) {
+                logger.warn("Application version is incorrect, application key: {}", applicationKey);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+            }
+
+            ApplicationEntity application = applicationVersion.getApplication();
+            // if there is no such application, exit
+            if (application == null) {
+                logger.warn("Application is incorrect, application key: {}", applicationKey);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+
+            // Create an activation record and obtain the activation database record
+            String activationId = this.initActivation(application.getId(), userId, maxFailedCount, activationExpireTimestamp, keyConversionUtilities);
+            ActivationRecordEntity activation = activationRepository.findActivation(activationId);
+
+            // Get master private key
+            String masterPrivateKeyBase64 = activation.getMasterKeyPair().getMasterKeyPrivateBase64();
+            byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
+            PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
+
+            // Get client ephemeral public key
+            PublicKey clientEphemeralPublicKey = null;
+            if (clientEphemeralPublicKeyBase64 != null) { // additional encryption is used
+                byte[] clientEphemeralPublicKeyBytes = BaseEncoding.base64().decode(clientEphemeralPublicKeyBase64);
+                clientEphemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(clientEphemeralPublicKeyBytes);
+            }
+
+            // Decrypt the device public key
+            byte[] C_devicePublicKey = BaseEncoding.base64().decode(cDevicePublicKeyBase64);
+            byte[] activationNonce = BaseEncoding.base64().decode(activationNonceBase64);
+
+            PublicKey devicePublicKey = null;
+            try {
+                devicePublicKey = powerAuthServerActivation.decryptDevicePublicKey(
+                        C_devicePublicKey,
+                        identity,
+                        masterPrivateKey,
+                        clientEphemeralPublicKey,
+                        activationOtp,
+                        activationNonce
+                );
+            } catch (GenericCryptoException ex) {
+                handleInvalidPublicKey(activation);
+            }
+
+            byte[] applicationSignatureBytes = BaseEncoding.base64().decode(applicationSignature);
+
+            if (!powerAuthServerActivation.validateApplicationSignature(
+                    identity,
+                    activationNonce,
+                    C_devicePublicKey,
+                    BaseEncoding.base64().decode(applicationKey),
+                    BaseEncoding.base64().decode(applicationVersion.getApplicationSecret()),
+                    applicationSignatureBytes)) {
+                logger.warn("Activation signature is invalid, activation ID: {}", activationId);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+
+            // Update and persist the activation record
+            activation.setActivationStatus(ActivationStatus.OTP_USED);
+            activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setActivationName(activationName);
+            activation.setExtras(extras);
+            // PowerAuth protocol version 2.0 and 2.1 uses 0x2 as version
+            activation.setVersion(2);
+            // Hash based counter is not used in this version
+            activation.setCtrDataBase64(null);
+            activationRepository.save(activation);
+            activationHistoryServiceBehavior.logActivationStatusChange(activation);
+            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+
+            // Generate response data
+            byte[] activationNonceServer = powerAuthServerActivation.generateActivationNonce();
+            String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
+            PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
+            KeyPair ephemeralKeyPair = new KeyGenerator().generateKeyPair();
+            PrivateKey ephemeralPrivateKey = ephemeralKeyPair.getPrivate();
+            PublicKey ephemeralPublicKey = ephemeralKeyPair.getPublic();
+            byte[] ephemeralPublicKeyBytes = keyConversionUtilities.convertPublicKeyToBytes(ephemeralPublicKey);
+
+            // Encrypt the public key
+            byte[] C_serverPublicKey = powerAuthServerActivation.encryptServerPublicKey(serverPublicKey, devicePublicKey, ephemeralPrivateKey, activationOtp, identity, activationNonceServer);
+
+            // Get encrypted public key signature
+            byte[] C_serverPubKeySignature = powerAuthServerActivation.computeServerDataSignature(activation.getActivationId(), C_serverPublicKey, masterPrivateKey);
+            if (C_serverPubKeySignature == null) { // in case there is a technical error with signing and null is returned, return random bytes
+                C_serverPubKeySignature = new KeyGenerator().generateRandomBytes(71);
+            }
+
+            // Compute the response
+            CreateActivationResponse response = new CreateActivationResponse();
+            response.setActivationId(activation.getActivationId());
+            response.setActivationNonce(BaseEncoding.base64().encode(activationNonceServer));
+            response.setEncryptedServerPublicKey(BaseEncoding.base64().encode(C_serverPublicKey));
+            response.setEncryptedServerPublicKeySignature(BaseEncoding.base64().encode(C_serverPubKeySignature));
+            response.setEphemeralPublicKey(BaseEncoding.base64().encode(ephemeralPublicKeyBytes));
+
+            return response;
+        } catch (InvalidKeySpecException | InvalidKeyException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
-
-        ApplicationEntity application = applicationVersion.getApplication();
-        // if there is no such application, exit
-        if (application == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-
-        // Create an activation record and obtain the activation database record
-        String activationId = this.initActivation(application.getId(), userId, maxFailedCount, activationExpireTimestamp, keyConversionUtilities);
-        ActivationRecordEntity activation = activationRepository.findActivation(activationId);
-
-        // Get master private key
-        String masterPrivateKeyBase64 = activation.getMasterKeyPair().getMasterKeyPrivateBase64();
-        byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
-        PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
-
-        // Get client ephemeral public key
-        PublicKey clientEphemeralPublicKey = null;
-        if (clientEphemeralPublicKeyBase64 != null) { // additional encryption is used
-            byte[] clientEphemeralPublicKeyBytes = BaseEncoding.base64().decode(clientEphemeralPublicKeyBase64);
-            clientEphemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(clientEphemeralPublicKeyBytes);
-        }
-
-        // Decrypt the device public key
-        byte[] C_devicePublicKey = BaseEncoding.base64().decode(cDevicePublicKeyBase64);
-        byte[] activationNonce = BaseEncoding.base64().decode(activationNonceBase64);
-        PublicKey devicePublicKey = powerAuthServerActivation.decryptDevicePublicKey(
-                C_devicePublicKey,
-                identity,
-                masterPrivateKey,
-                clientEphemeralPublicKey,
-                activationOtp,
-                activationNonce
-        );
-
-        validateNotNullPublicKey(activation, devicePublicKey);
-
-        byte[] applicationSignatureBytes = BaseEncoding.base64().decode(applicationSignature);
-
-        if (!powerAuthServerActivation.validateApplicationSignature(
-                identity,
-                activationNonce,
-                C_devicePublicKey,
-                BaseEncoding.base64().decode(applicationKey),
-                BaseEncoding.base64().decode(applicationVersion.getApplicationSecret()),
-                applicationSignatureBytes)) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-
-        // Update and persist the activation record
-        activation.setActivationStatus(ActivationStatus.OTP_USED);
-        activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
-        activation.setActivationName(activationName);
-        activation.setExtras(extras);
-        // PowerAuth protocol version 2.0 and 2.1 uses 0x2 as version
-        activation.setVersion(2);
-        // Hash based counter is not used in this version
-        activation.setCtrDataBase64(null);
-        activationRepository.save(activation);
-        activationHistoryServiceBehavior.logActivationStatusChange(activation);
-        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-
-        // Generate response data
-        byte[] activationNonceServer = powerAuthServerActivation.generateActivationNonce();
-        String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
-        PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
-        KeyPair ephemeralKeyPair = new KeyGenerator().generateKeyPair();
-        PrivateKey ephemeralPrivateKey = ephemeralKeyPair.getPrivate();
-        PublicKey ephemeralPublicKey = ephemeralKeyPair.getPublic();
-        byte[] ephemeralPublicKeyBytes = keyConversionUtilities.convertPublicKeyToBytes(ephemeralPublicKey);
-
-        // Encrypt the public key
-        byte[] C_serverPublicKey = powerAuthServerActivation.encryptServerPublicKey(serverPublicKey, devicePublicKey, ephemeralPrivateKey, activationOtp, identity, activationNonceServer);
-
-        // Get encrypted public key signature
-        byte[] C_serverPubKeySignature = powerAuthServerActivation.computeServerDataSignature(activation.getActivationId(), C_serverPublicKey, masterPrivateKey);
-        if (C_serverPubKeySignature == null) { // in case there is a technical error with signing and null is returned, return random bytes
-            C_serverPubKeySignature = new KeyGenerator().generateRandomBytes(71);
-        }
-
-        // Compute the response
-        CreateActivationResponse response = new CreateActivationResponse();
-        response.setActivationId(activation.getActivationId());
-        response.setActivationNonce(BaseEncoding.base64().encode(activationNonceServer));
-        response.setEncryptedServerPublicKey(BaseEncoding.base64().encode(C_serverPublicKey));
-        response.setEncryptedServerPublicKeySignature(BaseEncoding.base64().encode(C_serverPubKeySignature));
-        response.setEphemeralPublicKey(BaseEncoding.base64().encode(ephemeralPublicKeyBytes));
-
-        return response;
     }
 
     /**
@@ -449,135 +479,138 @@ public class ActivationServiceBehavior {
      * @param activationExpireTimestamp Timestamp after which activation can no longer be completed
      * @param keyConversionUtilities    Utility class for key conversion
      * @return Response with activation initialization data
-     * @throws GenericServiceException If invalid values are provided.
-     * @throws InvalidKeySpecException If invalid key is provided
-     * @throws InvalidKeyException     If invalid key is provided
+     * @throws GenericServiceException  If init activation fails.
      */
-    private String initActivation(Long applicationId, String userId, Long maxFailedCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException {
-        // Generate timestamp in advance
-        Date timestamp = new Date();
+    private String initActivation(Long applicationId, String userId, Long maxFailedCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
+        try {
+            // Generate timestamp in advance
+            Date timestamp = new Date();
 
-        if (userId == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.NO_USER_ID);
-        }
-
-        if (applicationId == 0L) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
-        }
-
-        // Application version is not being checked in initActivation, it is checked later in prepareActivation or createActivation.
-
-        // Get the repository
-        final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
-        final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
-
-        // Get number of max attempts from request or from constants, if not provided
-        Long maxAttempt = maxFailedCount;
-        if (maxAttempt == null) {
-            maxAttempt = powerAuthServiceConfiguration.getSignatureMaxFailedAttempts();
-        }
-
-        // Get activation expiration date from request or from constants, if not provided
-        Date timestampExpiration = activationExpireTimestamp;
-        if (timestampExpiration == null) {
-            timestampExpiration = new Date(timestamp.getTime() + powerAuthServiceConfiguration.getActivationValidityBeforeActive());
-        }
-
-        // Fetch the latest master private key
-        MasterKeyPairEntity masterKeyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationId);
-        if (masterKeyPair == null) {
-            GenericServiceException ex = localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
-            logger.error("No master key pair found for application ID: {}", applicationId, ex);
-            throw ex;
-        }
-        byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterKeyPair.getMasterKeyPrivateBase64());
-        PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
-        if (masterPrivateKey == null) {
-            GenericServiceException ex = localizationProvider.buildExceptionForCode(ServiceError.INCORRECT_MASTER_SERVER_KEYPAIR_PRIVATE);
-            logger.error("Master private key is invalid for application ID {} ", applicationId, ex);
-            throw ex;
-        }
-
-        // Generate new activation data, generate a unique activation ID
-        String activationId = null;
-        for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationIdIterations(); i++) {
-            String tmpActivationId = powerAuthServerActivation.generateActivationId();
-            ActivationRecordEntity record = activationRepository.findActivation(tmpActivationId);
-            if (record == null) {
-                activationId = tmpActivationId;
-                break;
-            } // ... else this activation ID has a collision, reset it and try to find another one
-        }
-        if (activationId == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_ACTIVATION_ID);
-        }
-
-        // Generate a unique short activation ID for created and OTP used states
-        String activationCode = null;
-        Set<io.getlime.security.powerauth.app.server.database.model.ActivationStatus> states = ImmutableSet.of(io.getlime.security.powerauth.app.server.database.model.ActivationStatus.CREATED, io.getlime.security.powerauth.app.server.database.model.ActivationStatus.OTP_USED);
-        for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationShortIdIterations(); i++) {
-            String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
-            ActivationRecordEntity record = activationRepository.findCreatedActivation(applicationId, tmpActivationCode, states, timestamp);
-            // this activation short ID has a collision, reset it and find
-            // another one
-            if (record == null) {
-                activationCode = tmpActivationCode;
-                break;
+            if (userId == null) {
+                logger.warn("User ID not specified");
+                throw localizationProvider.buildExceptionForCode(ServiceError.NO_USER_ID);
             }
+
+            if (applicationId == 0L) {
+                logger.warn("Application ID not specified");
+                throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
+            }
+
+            // Application version is not being checked in initActivation, it is checked later in prepareActivation or createActivation.
+
+            // Get the repository
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+            final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
+
+            // Get number of max attempts from request or from constants, if not provided
+            Long maxAttempt = maxFailedCount;
+            if (maxAttempt == null) {
+                maxAttempt = powerAuthServiceConfiguration.getSignatureMaxFailedAttempts();
+            }
+
+            // Get activation expiration date from request or from constants, if not provided
+            Date timestampExpiration = activationExpireTimestamp;
+            if (timestampExpiration == null) {
+                timestampExpiration = new Date(timestamp.getTime() + powerAuthServiceConfiguration.getActivationValidityBeforeActive());
+            }
+
+            // Fetch the latest master private key
+            MasterKeyPairEntity masterKeyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationId);
+            if (masterKeyPair == null) {
+                GenericServiceException ex = localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
+                logger.error("No master key pair found for application ID: {}", applicationId);
+                throw ex;
+            }
+            byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterKeyPair.getMasterKeyPrivateBase64());
+            PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
+
+            // Generate new activation data, generate a unique activation ID
+            String activationId = null;
+            for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationIdIterations(); i++) {
+                String tmpActivationId = powerAuthServerActivation.generateActivationId();
+                ActivationRecordEntity record = activationRepository.findActivation(tmpActivationId);
+                if (record == null) {
+                    activationId = tmpActivationId;
+                    break;
+                } // ... else this activation ID has a collision, reset it and try to find another one
+            }
+            if (activationId == null) {
+                logger.error("Unable to generate activation ID");
+                throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_ACTIVATION_ID);
+            }
+
+            // Generate a unique short activation ID for created and OTP used states
+            String activationCode = null;
+            Set<io.getlime.security.powerauth.app.server.database.model.ActivationStatus> states = ImmutableSet.of(io.getlime.security.powerauth.app.server.database.model.ActivationStatus.CREATED, io.getlime.security.powerauth.app.server.database.model.ActivationStatus.OTP_USED);
+            for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationShortIdIterations(); i++) {
+                String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
+                ActivationRecordEntity record = activationRepository.findCreatedActivation(applicationId, tmpActivationCode, states, timestamp);
+                // this activation short ID has a collision, reset it and find
+                // another one
+                if (record == null) {
+                    activationCode = tmpActivationCode;
+                    break;
+                }
+            }
+            if (activationCode == null) {
+                logger.error("Unable to generate short activation ID");
+                throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_SHORT_ACTIVATION_ID);
+            }
+
+            // Compute activation signature
+            byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(activationCode, masterPrivateKey);
+
+            // Encode the signature
+            String activationSignatureBase64 = BaseEncoding.base64().encode(activationSignature);
+
+            // Generate server key pair
+            KeyPair serverKeyPair = powerAuthServerActivation.generateServerKeyPair();
+            byte[] serverKeyPrivateBytes = keyConversionUtilities.convertPrivateKeyToBytes(serverKeyPair.getPrivate());
+            byte[] serverKeyPublicBytes = keyConversionUtilities.convertPublicKeyToBytes(serverKeyPair.getPublic());
+
+            // Store the new activation
+            ActivationRecordEntity activation = new ActivationRecordEntity();
+            activation.setActivationId(activationId);
+            activation.setActivationCode(activationCode);
+            activation.setActivationName(null);
+            activation.setActivationStatus(ActivationStatus.CREATED);
+            activation.setCounter(0L);
+            activation.setCtrDataBase64(null);
+            activation.setDevicePublicKeyBase64(null);
+            activation.setExtras(null);
+            activation.setFailedAttempts(0L);
+            activation.setApplication(masterKeyPair.getApplication());
+            activation.setMasterKeyPair(masterKeyPair);
+            activation.setMaxFailedAttempts(maxAttempt);
+            activation.setServerPublicKeyBase64(BaseEncoding.base64().encode(serverKeyPublicBytes));
+            activation.setTimestampActivationExpire(timestampExpiration);
+            activation.setTimestampCreated(timestamp);
+            activation.setTimestampLastUsed(timestamp);
+            // Activation version is not known yet
+            activation.setVersion(null);
+            activation.setUserId(userId);
+
+            // Convert server private key to DB columns serverPrivateKeyEncryption specifying encryption mode and serverPrivateKey with base64-encoded key.
+            ServerPrivateKey serverPrivateKey = serverPrivateKeyConverter.toDBValue(serverKeyPrivateBytes, userId, activationId);
+            activation.setServerPrivateKeyEncryption(serverPrivateKey.getKeyEncryptionMode());
+            activation.setServerPrivateKeyBase64(serverPrivateKey.getServerPrivateKeyBase64());
+
+            // A reference to saved ActivationRecordEntity is required when logging activation status change, otherwise issue #57 occurs on Oracle.
+            activation = activationRepository.save(activation);
+            activationHistoryServiceBehavior.logActivationStatusChange(activation);
+            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+
+            return activationId;
+        } catch (InvalidKeySpecException | InvalidKeyException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INCORRECT_MASTER_SERVER_KEYPAIR_PRIVATE);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
-        if (activationCode == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_SHORT_ACTIVATION_ID);
-        }
-
-        // Compute activation signature
-        byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(activationCode, masterPrivateKey);
-
-        // Happens only when there is a crypto provider setup issue (SignatureException).
-        if (activationSignature == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_COMPUTE_SIGNATURE);
-        }
-
-        // Encode the signature
-        String activationSignatureBase64 = BaseEncoding.base64().encode(activationSignature);
-
-        // Generate server key pair
-        KeyPair serverKeyPair = powerAuthServerActivation.generateServerKeyPair();
-        byte[] serverKeyPrivateBytes = keyConversionUtilities.convertPrivateKeyToBytes(serverKeyPair.getPrivate());
-        byte[] serverKeyPublicBytes = keyConversionUtilities.convertPublicKeyToBytes(serverKeyPair.getPublic());
-
-        // Store the new activation
-        ActivationRecordEntity activation = new ActivationRecordEntity();
-        activation.setActivationId(activationId);
-        activation.setActivationCode(activationCode);
-        activation.setActivationName(null);
-        activation.setActivationStatus(ActivationStatus.CREATED);
-        activation.setCounter(0L);
-        activation.setCtrDataBase64(null);
-        activation.setDevicePublicKeyBase64(null);
-        activation.setExtras(null);
-        activation.setFailedAttempts(0L);
-        activation.setApplication(masterKeyPair.getApplication());
-        activation.setMasterKeyPair(masterKeyPair);
-        activation.setMaxFailedAttempts(maxAttempt);
-        activation.setServerPublicKeyBase64(BaseEncoding.base64().encode(serverKeyPublicBytes));
-        activation.setTimestampActivationExpire(timestampExpiration);
-        activation.setTimestampCreated(timestamp);
-        activation.setTimestampLastUsed(timestamp);
-        // Activation version is not known yet
-        activation.setVersion(null);
-        activation.setUserId(userId);
-
-        // Convert server private key to DB columns serverPrivateKeyEncryption specifying encryption mode and serverPrivateKey with base64-encoded key.
-        ServerPrivateKey serverPrivateKey = serverPrivateKeyConverter.toDBValue(serverKeyPrivateBytes, userId, activationId);
-        activation.setServerPrivateKeyEncryption(serverPrivateKey.getKeyEncryptionMode());
-        activation.setServerPrivateKeyBase64(serverPrivateKey.getServerPrivateKeyBase64());
-
-        // A reference to saved ActivationRecordEntity is required when logging activation status change, otherwise issue #57 occurs on Oracle.
-        activation = activationRepository.save(activation);
-        activationHistoryServiceBehavior.logActivationStatusChange(activation);
-        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-
-      return activationId;
     }
 
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -17,6 +17,7 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v3;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.BaseEncoding;
@@ -49,9 +50,11 @@ import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCrypt
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
 import io.getlime.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import io.getlime.security.powerauth.v3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +65,6 @@ import javax.crypto.SecretKey;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
@@ -157,21 +159,19 @@ public class ActivationServiceBehavior {
     }
 
     /**
-     * Validate provided public key and if the key is null, remove provided activation
-     * (mark as REMOVED), notify callback listeners, and throw exception.
+     * Handle case when public key is invalid. Remove provided activation (mark as REMOVED),
+     * notify callback listeners, and throw an exception.
      *
-     * @param activation Activation to be removed in case the device public key is not valid.
-     * @param devicePublicKey Device public key to be checked.
-     * @throws GenericServiceException In case provided public key is null.
+     * @param activation Activation to be removed.
+     * @throws GenericServiceException Error caused by invalid public key.
      */
-    private void validateNotNullPublicKey(ActivationRecordEntity activation, PublicKey devicePublicKey) throws GenericServiceException {
-        if (devicePublicKey == null) { // invalid key was sent, return error
-            activation.setActivationStatus(ActivationStatus.REMOVED);
-            repositoryCatalogue.getActivationRepository().save(activation);
-            activationHistoryServiceBehavior.logActivationStatusChange(activation);
-            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
-        }
+    private void handleInvalidPublicKey(ActivationRecordEntity activation) throws GenericServiceException {
+        activation.setActivationStatus(ActivationStatus.REMOVED);
+        repositoryCatalogue.getActivationRepository().save(activation);
+        activationHistoryServiceBehavior.logActivationStatusChange(activation);
+        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+        logger.warn("Invalid public key, activation ID: {}", activation.getActivationId());
+        throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
     }
 
     /**
@@ -187,11 +187,13 @@ public class ActivationServiceBehavior {
         if (activation == null
                 || !ActivationStatus.CREATED.equals(activation.getActivationStatus())
                 || !Objects.equals(activation.getApplication().getId(), application.getId())) {
+            logger.info("Activation is expired, activation ID: {}", activation != null ? activation.getActivationId() : "unknown");
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
         }
 
         // Make sure activation code has 23 characters
         if (activation.getActivationCode().length() != 23) {
+            logger.info("Activation code is invalid, activation ID: {}", activation.getActivationId());
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
         }
     }
@@ -253,156 +255,164 @@ public class ActivationServiceBehavior {
      * @param keyConversionUtilities Key conversion utility class
      * @return Activation status response
      * @throws DatatypeConfigurationException Thrown when calendar conversion fails.
-     * @throws InvalidKeySpecException        Thrown when invalid key is provided.
-     * @throws InvalidKeyException            Thrown when invalid key is provided.
-     * @throws GenericServiceException        Thrown when any other error occurs.
+     * @throws GenericServiceException        Thrown when cryptography error occurs.
      */
-    public GetActivationStatusResponse getActivationStatus(String activationId, CryptoProviderUtil keyConversionUtilities) throws DatatypeConfigurationException, InvalidKeySpecException, InvalidKeyException, GenericServiceException {
+    public GetActivationStatusResponse getActivationStatus(String activationId, CryptoProviderUtil keyConversionUtilities) throws DatatypeConfigurationException, GenericServiceException {
+        try {
+            // Generate timestamp in advance
+            Date timestamp = new Date();
 
-        // Generate timestamp in advance
-        Date timestamp = new Date();
+            // Get the repository
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+            final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
 
-        // Get the repository
-        final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
-        final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
+            ActivationRecordEntity activation = activationRepository.findActivation(activationId);
 
-        ActivationRecordEntity activation = activationRepository.findActivation(activationId);
+            // Check if the activation exists
+            if (activation != null) {
 
-        // Check if the activation exists
-        if (activation != null) {
+                // Deactivate old pending activations first
+                deactivatePendingActivation(timestamp, activation);
 
-            // Deactivate old pending activations first
-            deactivatePendingActivation(timestamp, activation);
+                // Handle CREATED activation
+                if (activation.getActivationStatus() == io.getlime.security.powerauth.app.server.database.model.ActivationStatus.CREATED) {
 
-            // Handle CREATED activation
-            if (activation.getActivationStatus() == io.getlime.security.powerauth.app.server.database.model.ActivationStatus.CREATED) {
+                    // Created activations are not able to transfer valid status blob to the client
+                    // since both keys were not exchanged yet and transport cannot be secured.
+                    byte[] randomStatusBlob = new KeyGenerator().generateRandomBytes(16);
 
-                // Created activations are not able to transfer valid status blob to the client
-                // since both keys were not exchanged yet and transport cannot be secured.
-                byte[] randomStatusBlob = new KeyGenerator().generateRandomBytes(16);
-
-                // Activation signature
-                String masterPrivateKeyBase64 = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(activation.getApplication().getId()).getMasterKeyPrivateBase64();
-                byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
-                byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(
-                        activation.getActivationCode(),
-                        keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes)
-                );
-
-                // Happens only when there is a crypto provider setup issue (SignatureException).
-                if (activationSignature == null) {
-                    throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_COMPUTE_SIGNATURE);
-                }
-
-                // return the data
-                GetActivationStatusResponse response = new GetActivationStatusResponse();
-                response.setActivationId(activationId);
-                response.setUserId(activation.getUserId());
-                response.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));
-                response.setBlockedReason(activation.getBlockedReason());
-                response.setActivationName(activation.getActivationName());
-                response.setExtras(activation.getExtras());
-                response.setApplicationId(activation.getApplication().getId());
-                response.setTimestampCreated(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampCreated()));
-                response.setTimestampLastUsed(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampLastUsed()));
-                response.setEncryptedStatusBlob(BaseEncoding.base64().encode(randomStatusBlob));
-                response.setActivationCode(activation.getActivationCode());
-                response.setActivationSignature(BaseEncoding.base64().encode(activationSignature));
-                response.setDevicePublicKeyFingerprint(null);
-                // Unknown version is converted to 0 in SOAP
-                response.setVersion(activation.getVersion() == null ? 0L : activation.getVersion());
-                return response;
-
-            } else {
-
-                // Get the server private and device public keys to compute the transport key
-                String devicePublicKeyBase64 = activation.getDevicePublicKeyBase64();
-
-                // Decrypt server private key (depending on encryption mode)
-                String serverPrivateKeyFromEntity = activation.getServerPrivateKeyBase64();
-                KeyEncryptionMode serverPrivateKeyEncryptionMode = activation.getServerPrivateKeyEncryption();
-                String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity, activation.getUserId(), activationId);
-
-                // If an activation was turned to REMOVED directly from CREATED state,
-                // there is not device public key in the database - we need to handle
-                // that case by defaulting the C_statusBlob to random value...
-                byte[] C_statusBlob = new KeyGenerator().generateRandomBytes(16);
-
-                // Prepare a value for the device public key fingerprint
-                String activationFingerPrint = null;
-
-                // There is a device public key available, therefore we can compute
-                // the real C_statusBlob value.
-                if (devicePublicKeyBase64 != null) {
-
-                    PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(BaseEncoding.base64().decode(serverPrivateKeyBase64));
-                    PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(devicePublicKeyBase64));
-
-                    SecretKey masterSecretKey = powerAuthServerKeyFactory.generateServerMasterSecretKey(serverPrivateKey, devicePublicKey);
-                    SecretKey transportKey = powerAuthServerKeyFactory.generateServerTransportKey(masterSecretKey);
-
-                    // Encrypt the status blob
-                    C_statusBlob = powerAuthServerActivation.encryptedStatusBlob(
-                            activation.getActivationStatus().getByte(),
-                            activation.getVersion().byteValue(),
-                            POWERAUTH_PROTOCOL_VERSION,
-                            activation.getFailedAttempts().byteValue(),
-                            activation.getMaxFailedAttempts().byteValue(),
-                            transportKey
+                    // Activation signature
+                    MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(activation.getApplication().getId());
+                    if (masterKeyPairEntity == null) {
+                        logger.error("Missing key pair for application ID: {}", activation.getApplication().getId());
+                        throw localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
+                    }
+                    String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
+                    byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
+                    byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(
+                            activation.getActivationCode(),
+                            keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes)
                     );
 
-                    // Assign the activation fingerprint
-                    activationFingerPrint = powerAuthServerActivation.computeDevicePublicKeyFingerprint(devicePublicKey);
+                    // return the data
+                    GetActivationStatusResponse response = new GetActivationStatusResponse();
+                    response.setActivationId(activationId);
+                    response.setUserId(activation.getUserId());
+                    response.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));
+                    response.setBlockedReason(activation.getBlockedReason());
+                    response.setActivationName(activation.getActivationName());
+                    response.setExtras(activation.getExtras());
+                    response.setApplicationId(activation.getApplication().getId());
+                    response.setTimestampCreated(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampCreated()));
+                    response.setTimestampLastUsed(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampLastUsed()));
+                    response.setEncryptedStatusBlob(BaseEncoding.base64().encode(randomStatusBlob));
+                    response.setActivationCode(activation.getActivationCode());
+                    response.setActivationSignature(BaseEncoding.base64().encode(activationSignature));
+                    response.setDevicePublicKeyFingerprint(null);
+                    // Unknown version is converted to 0 in SOAP
+                    response.setVersion(activation.getVersion() == null ? 0L : activation.getVersion());
+                    return response;
+
+                } else {
+
+                    // Get the server private and device public keys to compute the transport key
+                    String devicePublicKeyBase64 = activation.getDevicePublicKeyBase64();
+
+                    // Decrypt server private key (depending on encryption mode)
+                    String serverPrivateKeyFromEntity = activation.getServerPrivateKeyBase64();
+                    KeyEncryptionMode serverPrivateKeyEncryptionMode = activation.getServerPrivateKeyEncryption();
+                    String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity, activation.getUserId(), activationId);
+
+                    // If an activation was turned to REMOVED directly from CREATED state,
+                    // there is not device public key in the database - we need to handle
+                    // that case by defaulting the C_statusBlob to random value...
+                    byte[] C_statusBlob = new KeyGenerator().generateRandomBytes(16);
+
+                    // Prepare a value for the device public key fingerprint
+                    String activationFingerPrint = null;
+
+                    // There is a device public key available, therefore we can compute
+                    // the real C_statusBlob value.
+                    if (devicePublicKeyBase64 != null) {
+
+                        PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(BaseEncoding.base64().decode(serverPrivateKeyBase64));
+                        PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(devicePublicKeyBase64));
+
+                        SecretKey masterSecretKey = powerAuthServerKeyFactory.generateServerMasterSecretKey(serverPrivateKey, devicePublicKey);
+                        SecretKey transportKey = powerAuthServerKeyFactory.generateServerTransportKey(masterSecretKey);
+
+                        // Encrypt the status blob
+                        C_statusBlob = powerAuthServerActivation.encryptedStatusBlob(
+                                activation.getActivationStatus().getByte(),
+                                activation.getVersion().byteValue(),
+                                POWERAUTH_PROTOCOL_VERSION,
+                                activation.getFailedAttempts().byteValue(),
+                                activation.getMaxFailedAttempts().byteValue(),
+                                transportKey
+                        );
+
+                        // Assign the activation fingerprint
+                        activationFingerPrint = powerAuthServerActivation.computeDevicePublicKeyFingerprint(devicePublicKey);
+
+                    }
+
+                    // return the data
+                    GetActivationStatusResponse response = new GetActivationStatusResponse();
+                    response.setActivationId(activationId);
+                    response.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));
+                    response.setBlockedReason(activation.getBlockedReason());
+                    response.setActivationName(activation.getActivationName());
+                    response.setUserId(activation.getUserId());
+                    response.setExtras(activation.getExtras());
+                    response.setApplicationId(activation.getApplication().getId());
+                    response.setTimestampCreated(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampCreated()));
+                    response.setTimestampLastUsed(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampLastUsed()));
+                    response.setEncryptedStatusBlob(BaseEncoding.base64().encode(C_statusBlob));
+                    response.setActivationCode(null);
+                    response.setActivationSignature(null);
+                    response.setDevicePublicKeyFingerprint(activationFingerPrint);
+                    // Unknown version is converted to 0 in SOAP
+                    response.setVersion(activation.getVersion() == null ? 0L : activation.getVersion());
+                    return response;
 
                 }
+            } else {
+
+                // Activations that do not exist should return REMOVED state and
+                // a random status blob
+                byte[] randomStatusBlob = new KeyGenerator().generateRandomBytes(16);
+
+                // Generate date
+                XMLGregorianCalendar zeroDate = XMLGregorianCalendarConverter.convertFrom(new Date(0));
 
                 // return the data
                 GetActivationStatusResponse response = new GetActivationStatusResponse();
                 response.setActivationId(activationId);
-                response.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));
-                response.setBlockedReason(activation.getBlockedReason());
-                response.setActivationName(activation.getActivationName());
-                response.setUserId(activation.getUserId());
-                response.setExtras(activation.getExtras());
-                response.setApplicationId(activation.getApplication().getId());
-                response.setTimestampCreated(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampCreated()));
-                response.setTimestampLastUsed(XMLGregorianCalendarConverter.convertFrom(activation.getTimestampLastUsed()));
-                response.setEncryptedStatusBlob(BaseEncoding.base64().encode(C_statusBlob));
+                response.setActivationStatus(activationStatusConverter.convert(ActivationStatus.REMOVED));
+                response.setBlockedReason(null);
+                response.setActivationName("unknown");
+                response.setUserId("unknown");
+                response.setApplicationId(0L);
+                response.setExtras(null);
+                response.setTimestampCreated(zeroDate);
+                response.setTimestampLastUsed(zeroDate);
+                response.setEncryptedStatusBlob(BaseEncoding.base64().encode(randomStatusBlob));
                 response.setActivationCode(null);
                 response.setActivationSignature(null);
-                response.setDevicePublicKeyFingerprint(activationFingerPrint);
-                // Unknown version is converted to 0 in SOAP
-                response.setVersion(activation.getVersion() == null ? 0L : activation.getVersion());
+                response.setDevicePublicKeyFingerprint(null);
+                // Use 0 as version when version is undefined
+                response.setVersion(0L);
                 return response;
-
             }
-        } else {
-
-            // Activations that do not exist should return REMOVED state and
-            // a random status blob
-            byte[] randomStatusBlob = new KeyGenerator().generateRandomBytes(16);
-
-            // Generate date
-            XMLGregorianCalendar zeroDate = XMLGregorianCalendarConverter.convertFrom(new Date(0));
-
-            // return the data
-            GetActivationStatusResponse response = new GetActivationStatusResponse();
-            response.setActivationId(activationId);
-            response.setActivationStatus(activationStatusConverter.convert(ActivationStatus.REMOVED));
-            response.setBlockedReason(null);
-            response.setActivationName("unknown");
-            response.setUserId("unknown");
-            response.setApplicationId(0L);
-            response.setExtras(null);
-            response.setTimestampCreated(zeroDate);
-            response.setTimestampLastUsed(zeroDate);
-            response.setEncryptedStatusBlob(BaseEncoding.base64().encode(randomStatusBlob));
-            response.setActivationCode(null);
-            response.setActivationSignature(null);
-            response.setDevicePublicKeyFingerprint(null);
-            // Use 0 as version when version is undefined
-            response.setVersion(0L);
-            return response;
+        } catch (InvalidKeySpecException | InvalidKeyException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
     }
 
@@ -416,142 +426,145 @@ public class ActivationServiceBehavior {
      * @param keyConversionUtilities    Utility class for key conversion
      * @return Response with activation initialization data
      * @throws GenericServiceException If invalid values are provided.
-     * @throws InvalidKeySpecException If invalid key is provided
-     * @throws InvalidKeyException     If invalid key is provided
      */
-    public InitActivationResponse initActivation(Long applicationId, String userId, Long maxFailedCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException {
-        // Generate timestamp in advance
-        Date timestamp = new Date();
+    public InitActivationResponse initActivation(Long applicationId, String userId, Long maxFailedCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
+        try {
+            // Generate timestamp in advance
+            Date timestamp = new Date();
 
-        if (userId == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.NO_USER_ID);
-        }
-
-        if (applicationId == 0L) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
-        }
-
-        // Application version is not being checked in initActivation, it is checked later in prepareActivation or createActivation.
-
-        // Get the repository
-        final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
-        final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
-
-        // Get number of max attempts from request or from constants, if not provided
-        Long maxAttempt = maxFailedCount;
-        if (maxAttempt == null) {
-            maxAttempt = powerAuthServiceConfiguration.getSignatureMaxFailedAttempts();
-        }
-
-        // Get activation expiration date from request or from constants, if not provided
-        Date timestampExpiration = activationExpireTimestamp;
-        if (timestampExpiration == null) {
-            timestampExpiration = new Date(timestamp.getTime() + powerAuthServiceConfiguration.getActivationValidityBeforeActive());
-        }
-
-        // Fetch the latest master private key
-        MasterKeyPairEntity masterKeyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationId);
-        if (masterKeyPair == null) {
-            GenericServiceException ex = localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
-            logger.error("No master key pair found for application ID: {}", applicationId, ex);
-            throw ex;
-        }
-        byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterKeyPair.getMasterKeyPrivateBase64());
-        PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
-        if (masterPrivateKey == null) {
-            GenericServiceException ex = localizationProvider.buildExceptionForCode(ServiceError.INCORRECT_MASTER_SERVER_KEYPAIR_PRIVATE);
-            logger.error("Master private key is invalid for application ID {} ", applicationId, ex);
-            throw ex;
-        }
-
-        // Generate new activation data, generate a unique activation ID
-        String activationId = null;
-        for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationIdIterations(); i++) {
-            String tmpActivationId = powerAuthServerActivation.generateActivationId();
-            ActivationRecordEntity record = activationRepository.findActivation(tmpActivationId);
-            if (record == null) {
-                activationId = tmpActivationId;
-                break;
-            } // ... else this activation ID has a collision, reset it and try to find another one
-        }
-        if (activationId == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_ACTIVATION_ID);
-        }
-
-        // Generate a unique short activation ID for created and OTP used states
-        String activationCode = null;
-        Set<io.getlime.security.powerauth.app.server.database.model.ActivationStatus> states = ImmutableSet.of(io.getlime.security.powerauth.app.server.database.model.ActivationStatus.CREATED, io.getlime.security.powerauth.app.server.database.model.ActivationStatus.OTP_USED);
-        for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationShortIdIterations(); i++) {
-            String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
-            ActivationRecordEntity record = activationRepository.findCreatedActivation(applicationId, tmpActivationCode, states, timestamp);
-            // this activation short ID has a collision, reset it and find
-            // another one
-            if (record == null) {
-                activationCode = tmpActivationCode;
-                break;
+            if (userId == null) {
+                logger.warn("User ID not specified");
+                throw localizationProvider.buildExceptionForCode(ServiceError.NO_USER_ID);
             }
+
+            if (applicationId == 0L) {
+                logger.warn("Application ID not specified");
+                throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
+            }
+
+            // Application version is not being checked in initActivation, it is checked later in prepareActivation or createActivation.
+
+            // Get the repository
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+            final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
+
+            // Get number of max attempts from request or from constants, if not provided
+            Long maxAttempt = maxFailedCount;
+            if (maxAttempt == null) {
+                maxAttempt = powerAuthServiceConfiguration.getSignatureMaxFailedAttempts();
+            }
+
+            // Get activation expiration date from request or from constants, if not provided
+            Date timestampExpiration = activationExpireTimestamp;
+            if (timestampExpiration == null) {
+                timestampExpiration = new Date(timestamp.getTime() + powerAuthServiceConfiguration.getActivationValidityBeforeActive());
+            }
+
+            // Fetch the latest master private key
+            MasterKeyPairEntity masterKeyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationId);
+            if (masterKeyPair == null) {
+                GenericServiceException ex = localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
+                logger.error("No master key pair found for application ID: {}", applicationId);
+                throw ex;
+            }
+            byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterKeyPair.getMasterKeyPrivateBase64());
+            PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
+
+            // Generate new activation data, generate a unique activation ID
+            String activationId = null;
+            for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationIdIterations(); i++) {
+                String tmpActivationId = powerAuthServerActivation.generateActivationId();
+                ActivationRecordEntity record = activationRepository.findActivation(tmpActivationId);
+                if (record == null) {
+                    activationId = tmpActivationId;
+                    break;
+                } // ... else this activation ID has a collision, reset it and try to find another one
+            }
+            if (activationId == null) {
+                logger.error("Unable to generate activation ID");
+                throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_ACTIVATION_ID);
+            }
+
+            // Generate a unique short activation ID for created and OTP used states
+            String activationCode = null;
+            Set<io.getlime.security.powerauth.app.server.database.model.ActivationStatus> states = ImmutableSet.of(io.getlime.security.powerauth.app.server.database.model.ActivationStatus.CREATED, io.getlime.security.powerauth.app.server.database.model.ActivationStatus.OTP_USED);
+            for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationShortIdIterations(); i++) {
+                String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
+                ActivationRecordEntity record = activationRepository.findCreatedActivation(applicationId, tmpActivationCode, states, timestamp);
+                // this activation short ID has a collision, reset it and find
+                // another one
+                if (record == null) {
+                    activationCode = tmpActivationCode;
+                    break;
+                }
+            }
+            if (activationCode == null) {
+                logger.error("Unable to generate short activation ID");
+                throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_SHORT_ACTIVATION_ID);
+            }
+
+
+            // Compute activation signature
+            byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(activationCode, masterPrivateKey);
+
+            // Encode the signature
+            String activationSignatureBase64 = BaseEncoding.base64().encode(activationSignature);
+
+            // Generate server key pair
+            KeyPair serverKeyPair = powerAuthServerActivation.generateServerKeyPair();
+            byte[] serverKeyPrivateBytes = keyConversionUtilities.convertPrivateKeyToBytes(serverKeyPair.getPrivate());
+            byte[] serverKeyPublicBytes = keyConversionUtilities.convertPublicKeyToBytes(serverKeyPair.getPublic());
+
+            // Store the new activation
+            ActivationRecordEntity activation = new ActivationRecordEntity();
+            activation.setActivationId(activationId);
+            activation.setActivationCode(activationCode);
+            activation.setActivationName(null);
+            activation.setActivationStatus(ActivationStatus.CREATED);
+            activation.setCounter(0L);
+            activation.setDevicePublicKeyBase64(null);
+            activation.setExtras(null);
+            activation.setFailedAttempts(0L);
+            activation.setApplication(masterKeyPair.getApplication());
+            activation.setMasterKeyPair(masterKeyPair);
+            activation.setMaxFailedAttempts(maxAttempt);
+            activation.setServerPublicKeyBase64(BaseEncoding.base64().encode(serverKeyPublicBytes));
+            activation.setTimestampActivationExpire(timestampExpiration);
+            activation.setTimestampCreated(timestamp);
+            activation.setTimestampLastUsed(timestamp);
+            // Activation version is not known yet
+            activation.setVersion(null);
+            activation.setUserId(userId);
+
+            // Convert server private key to DB columns serverPrivateKeyEncryption specifying encryption mode and serverPrivateKey with base64-encoded key.
+            ServerPrivateKey serverPrivateKey = serverPrivateKeyConverter.toDBValue(serverKeyPrivateBytes, userId, activationId);
+            activation.setServerPrivateKeyEncryption(serverPrivateKey.getKeyEncryptionMode());
+            activation.setServerPrivateKeyBase64(serverPrivateKey.getServerPrivateKeyBase64());
+
+            // A reference to saved ActivationRecordEntity is required when logging activation status change, otherwise issue #57 occurs on Oracle.
+            activation = activationRepository.save(activation);
+            activationHistoryServiceBehavior.logActivationStatusChange(activation);
+            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+
+            // Return the server response
+            InitActivationResponse response = new InitActivationResponse();
+            response.setActivationId(activationId);
+            response.setActivationCode(activationCode);
+            response.setUserId(userId);
+            response.setActivationSignature(activationSignatureBase64);
+            response.setApplicationId(activation.getApplication().getId());
+
+            return response;
+        } catch (InvalidKeySpecException | InvalidKeyException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INCORRECT_MASTER_SERVER_KEYPAIR_PRIVATE);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
-        if (activationCode == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_GENERATE_SHORT_ACTIVATION_ID);
-        }
-
-
-        // Compute activation signature
-        byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(activationCode, masterPrivateKey);
-
-        // Happens only when there is a crypto provider setup issue (SignatureException).
-        if (activationSignature == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.UNABLE_TO_COMPUTE_SIGNATURE);
-        }
-
-        // Encode the signature
-        String activationSignatureBase64 = BaseEncoding.base64().encode(activationSignature);
-
-        // Generate server key pair
-        KeyPair serverKeyPair = powerAuthServerActivation.generateServerKeyPair();
-        byte[] serverKeyPrivateBytes = keyConversionUtilities.convertPrivateKeyToBytes(serverKeyPair.getPrivate());
-        byte[] serverKeyPublicBytes = keyConversionUtilities.convertPublicKeyToBytes(serverKeyPair.getPublic());
-
-        // Store the new activation
-        ActivationRecordEntity activation = new ActivationRecordEntity();
-        activation.setActivationId(activationId);
-        activation.setActivationCode(activationCode);
-        activation.setActivationName(null);
-        activation.setActivationStatus(ActivationStatus.CREATED);
-        activation.setCounter(0L);
-        activation.setDevicePublicKeyBase64(null);
-        activation.setExtras(null);
-        activation.setFailedAttempts(0L);
-        activation.setApplication(masterKeyPair.getApplication());
-        activation.setMasterKeyPair(masterKeyPair);
-        activation.setMaxFailedAttempts(maxAttempt);
-        activation.setServerPublicKeyBase64(BaseEncoding.base64().encode(serverKeyPublicBytes));
-        activation.setTimestampActivationExpire(timestampExpiration);
-        activation.setTimestampCreated(timestamp);
-        activation.setTimestampLastUsed(timestamp);
-        // Activation version is not known yet
-        activation.setVersion(null);
-        activation.setUserId(userId);
-
-        // Convert server private key to DB columns serverPrivateKeyEncryption specifying encryption mode and serverPrivateKey with base64-encoded key.
-        ServerPrivateKey serverPrivateKey = serverPrivateKeyConverter.toDBValue(serverKeyPrivateBytes, userId, activationId);
-        activation.setServerPrivateKeyEncryption(serverPrivateKey.getKeyEncryptionMode());
-        activation.setServerPrivateKeyBase64(serverPrivateKey.getServerPrivateKeyBase64());
-
-        // A reference to saved ActivationRecordEntity is required when logging activation status change, otherwise issue #57 occurs on Oracle.
-        activation = activationRepository.save(activation);
-        activationHistoryServiceBehavior.logActivationStatusChange(activation);
-        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-
-        // Return the server response
-        InitActivationResponse response = new InitActivationResponse();
-        response.setActivationId(activationId);
-        response.setActivationCode(activationCode);
-        response.setUserId(userId);
-        response.setActivationSignature(activationSignatureBase64);
-        response.setApplicationId(activation.getApplication().getId());
-
-        return response;
     }
 
     /**
@@ -566,106 +579,129 @@ public class ActivationServiceBehavior {
      * @param applicationKey Application key.
      * @param eciesCryptogram Ecies cryptogram.
      * @return ECIES encrypted activation information.
+     * @throws GenericServiceException If invalid values are provided.
      */
-    public PrepareActivationResponse prepareActivation(String activationCode, String applicationKey, EciesCryptogram eciesCryptogram) throws GenericServiceException, InvalidKeySpecException, EciesException, IOException {
-        // Get current timestamp
-        Date timestamp = new Date();
-
-        // Get required repositories
-        final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
-        final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
-        final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
-
-        // Find application by application key
-        ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-        if (applicationVersion == null || !applicationVersion.getSupported()) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-        ApplicationEntity application = applicationVersion.getApplication();
-        if (application == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-
-        // Get master server private key
-        MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
-        String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
-        PrivateKey privateKey = keyConversion.convertBytesToPrivateKey(BaseEncoding.base64().decode(masterPrivateKeyBase64));
-        if (privateKey == null) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.INCORRECT_MASTER_SERVER_KEYPAIR_PRIVATE);
-        }
-
-        // Get application secret
-        byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
-
-        // Get ecies decryptor
-        EciesDecryptor eciesDecryptor = eciesFactory.getEciesDecryptorForApplication((ECPrivateKey) privateKey, applicationSecret, EciesSharedInfo1.ACTIVATION_LAYER_2);
-
-        // Decrypt activation data
-        byte[] activationData = eciesDecryptor.decryptRequest(eciesCryptogram);
-
-        // Convert JSON data to activation layer 2 request object
-        ActivationLayer2Request request;
+    public PrepareActivationResponse prepareActivation(String activationCode, String applicationKey, EciesCryptogram eciesCryptogram) throws GenericServiceException {
         try {
-            request = objectMapper.readValue(activationData, ActivationLayer2Request.class);
-        } catch (IOException ex) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+            // Get current timestamp
+            Date timestamp = new Date();
+
+            // Get required repositories
+            final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
+            final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+
+            // Find application by application key
+            ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
+            if (applicationVersion == null || !applicationVersion.getSupported()) {
+                logger.warn("Application version is incorrect, activation code: {}", activationCode);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+            ApplicationEntity application = applicationVersion.getApplication();
+            if (application == null) {
+                logger.warn("Application does not exist, activation code: {}", activationCode);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+
+            // Get master server private key
+            MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
+            if (masterKeyPairEntity == null) {
+                logger.error("Missing key pair for application ID: {}", application.getId());
+                throw localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
+            }
+
+            String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
+            PrivateKey privateKey = keyConversion.convertBytesToPrivateKey(BaseEncoding.base64().decode(masterPrivateKeyBase64));
+
+            // Get application secret
+            byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+
+            // Get ecies decryptor
+            EciesDecryptor eciesDecryptor = eciesFactory.getEciesDecryptorForApplication((ECPrivateKey) privateKey, applicationSecret, EciesSharedInfo1.ACTIVATION_LAYER_2);
+
+            // Decrypt activation data
+            byte[] activationData = eciesDecryptor.decryptRequest(eciesCryptogram);
+
+            // Convert JSON data to activation layer 2 request object
+            ActivationLayer2Request request;
+            try {
+                request = objectMapper.readValue(activationData, ActivationLayer2Request.class);
+            } catch (IOException ex) {
+                logger.warn("Invalid activation request, activation code: {}", activationCode);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+            }
+
+            // Fetch the current activation by activation code
+            Set<ActivationStatus> states = ImmutableSet.of(ActivationStatus.CREATED);
+            ActivationRecordEntity activation = activationRepository.findCreatedActivation(application.getId(), activationCode, states, timestamp);
+
+            // Make sure to deactivate the activation if it is expired
+            if (activation != null) {
+                deactivatePendingActivation(timestamp, activation);
+            }
+
+            // Validate that the activation is in correct state for the prepare step
+            validateActivationInPrepareStep(activation, application);
+
+            // Extract the device public key from request
+            byte[] devicePublicKeyBytes = BaseEncoding.base64().decode(request.getDevicePublicKey());
+            PublicKey devicePublicKey = null;
+
+            try {
+                devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
+            } catch (InvalidKeySpecException ex) {
+                handleInvalidPublicKey(activation);
+            }
+
+            // Initialize hash based counter
+            HashBasedCounter counter = new HashBasedCounter();
+            byte[] ctrData = counter.init();
+            String ctrDataBase64 = BaseEncoding.base64().encode(ctrData);
+
+            // Update and persist the activation record
+            activation.setActivationStatus(ActivationStatus.OTP_USED);
+            activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversion.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setActivationName(request.getActivationName());
+            activation.setExtras(request.getExtras());
+            // PowerAuth protocol version 3.0 uses 0x3 as version in activation status
+            activation.setVersion(3);
+            // Set initial counter data
+            activation.setCtrDataBase64(ctrDataBase64);
+            activationRepository.save(activation);
+            activationHistoryServiceBehavior.logActivationStatusChange(activation);
+            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+
+            // Generate activation layer 2 response
+            ActivationLayer2Response response = new ActivationLayer2Response();
+            response.setActivationId(activation.getActivationId());
+            response.setCtrData(ctrDataBase64);
+            response.setServerPublicKey(activation.getServerPublicKeyBase64());
+            byte[] responseData = objectMapper.writeValueAsBytes(response);
+
+            // Encrypt response data
+            EciesCryptogram responseCryptogram = eciesDecryptor.encryptResponse(responseData);
+            String encryptedData = BaseEncoding.base64().encode(responseCryptogram.getEncryptedData());
+            String mac = BaseEncoding.base64().encode(responseCryptogram.getMac());
+
+            // Generate encrypted response
+            PrepareActivationResponse encryptedResponse = new PrepareActivationResponse();
+            encryptedResponse.setActivationId(activation.getActivationId());
+            encryptedResponse.setEncryptedData(encryptedData);
+            encryptedResponse.setMac(mac);
+            return encryptedResponse;
+        } catch (InvalidKeySpecException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (EciesException | JsonProcessingException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
-
-        // Fetch the current activation by activation code
-        Set<ActivationStatus> states = ImmutableSet.of(ActivationStatus.CREATED);
-        ActivationRecordEntity activation = activationRepository.findCreatedActivation(application.getId(), activationCode, states, timestamp);
-
-        // Make sure to deactivate the activation if it is expired
-        if (activation != null) {
-            deactivatePendingActivation(timestamp, activation);
-        }
-
-        // Validate that the activation is in correct state for the prepare step
-        validateActivationInPrepareStep(activation, application);
-
-        // Extract the device public key from request
-        byte[] devicePublicKeyBytes = BaseEncoding.base64().decode(request.getDevicePublicKey());
-        PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
-
-        // Validate that public key is not null
-        validateNotNullPublicKey(activation, devicePublicKey);
-
-        // Initialize hash based counter
-        HashBasedCounter counter = new HashBasedCounter();
-        byte[] ctrData = counter.init();
-        String ctrDataBase64 = BaseEncoding.base64().encode(ctrData);
-
-        // Update and persist the activation record
-        activation.setActivationStatus(ActivationStatus.OTP_USED);
-        activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversion.convertPublicKeyToBytes(devicePublicKey)));
-        activation.setActivationName(request.getActivationName());
-        activation.setExtras(request.getExtras());
-        // PowerAuth protocol version 3.0 uses 0x3 as version in activation status
-        activation.setVersion(3);
-        // Set initial counter data
-        activation.setCtrDataBase64(ctrDataBase64);
-        activationRepository.save(activation);
-        activationHistoryServiceBehavior.logActivationStatusChange(activation);
-        callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
-
-        // Generate activation layer 2 response
-        ActivationLayer2Response response = new ActivationLayer2Response();
-        response.setActivationId(activation.getActivationId());
-        response.setCtrData(ctrDataBase64);
-        response.setServerPublicKey(activation.getServerPublicKeyBase64());
-        byte[] responseData = objectMapper.writeValueAsBytes(response);
-
-        // Encrypt response data
-        EciesCryptogram responseCryptogram = eciesDecryptor.encryptResponse(responseData);
-        String encryptedData = BaseEncoding.base64().encode(responseCryptogram.getEncryptedData());
-        String mac = BaseEncoding.base64().encode(responseCryptogram.getMac());
-
-        // Generate encrypted response
-        PrepareActivationResponse encryptedResponse = new PrepareActivationResponse();
-        encryptedResponse.setActivationId(activation.getActivationId());
-        encryptedResponse.setEncryptedData(encryptedData);
-        encryptedResponse.setMac(mac);
-        return encryptedResponse;
     }
 
     /**
@@ -693,7 +729,6 @@ public class ActivationServiceBehavior {
      * @throws GenericServiceException      In case invalid data is provided
      * @throws InvalidKeySpecException      If invalid key was provided
      * @throws InvalidKeyException          If invalid key was provided
-     * @throws UnsupportedEncodingException If UTF-8 is not supported on the system
      */
     public CreateActivationResponse createActivation(
             String applicationKey,
@@ -708,7 +743,7 @@ public class ActivationServiceBehavior {
             String activationName,
             String extras,
             String applicationSignature,
-            CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException, UnsupportedEncodingException {
+            CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException {
         throw new IllegalStateException("Not implemented yet.");
     }
 
@@ -735,6 +770,7 @@ public class ActivationServiceBehavior {
             // Check already deactivated activation
             deactivatePendingActivation(timestamp, activation);
             if (activation.getActivationStatus().equals(io.getlime.security.powerauth.app.server.database.model.ActivationStatus.REMOVED)) {
+                logger.info("Activation is already REMOVED, activation ID: {}", activationId);
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
             }
 
@@ -750,11 +786,13 @@ public class ActivationServiceBehavior {
                 response.setActivated(true);
                 return response;
             } else {
+                logger.info("Activation is not ACTIVE, activation ID: {}", activationId);
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE);
             }
 
         } else {
             // Activation does not exist
+            logger.info("Activation does not exist, activation ID: {}", activationId);
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
         }
     }
@@ -778,6 +816,7 @@ public class ActivationServiceBehavior {
             response.setRemoved(true);
             return response;
         } else {
+            logger.info("Activation does not exist, activation ID: {}", activationId);
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
         }
     }
@@ -793,6 +832,7 @@ public class ActivationServiceBehavior {
     public BlockActivationResponse blockActivation(String activationId, String reason) throws GenericServiceException {
         ActivationRecordEntity activation = repositoryCatalogue.getActivationRepository().findActivation(activationId);
         if (activation == null) {
+            logger.info("Activation does not exist, activation ID: {}", activationId);
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
         }
 
@@ -826,6 +866,7 @@ public class ActivationServiceBehavior {
     public UnblockActivationResponse unblockActivation(String activationId) throws GenericServiceException {
         ActivationRecordEntity activation = repositoryCatalogue.getActivationRepository().findActivation(activationId);
         if (activation == null) {
+            logger.info("Activation does not exist, activation ID: {}", activationId);
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
         }
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/CallbackUrlBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/CallbackUrlBehavior.java
@@ -80,6 +80,7 @@ public class CallbackUrlBehavior {
         try {
             new URL(request.getCallbackUrl());
         } catch (MalformedURLException e) {
+            logger.warn("Invalid callback URL: "+request.getCallbackUrl());
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_URL_FORMAT);
         }
 
@@ -121,7 +122,7 @@ public class CallbackUrlBehavior {
      * @param request Request specifying the callback URL to be removed.
      * @return Information about removal status.
      */
-    public RemoveCallbackUrlResponse removeIntegration(RemoveCallbackUrlRequest request) {
+    public RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request) {
         RemoveCallbackUrlResponse response = new RemoveCallbackUrlResponse();
         response.setId(request.getId());
         final Optional<CallbackUrlEntity> callbackUrlEntityOptional = callbackUrlRepository.findById(request.getId());

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/util/KeyDerivationUtil.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/util/KeyDerivationUtil.java
@@ -2,8 +2,10 @@ package io.getlime.security.powerauth.app.server.service.behavior.util;
 
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
@@ -30,8 +32,10 @@ public class KeyDerivationUtil {
      * @throws GenericServiceException Thrown when server private key could not be loaded from database.
      * @throws InvalidKeySpecException Thrown when key spec is invalid.
      * @throws InvalidKeyException Thrown when key is invalid.
+     * @throws CryptoProviderException Thrown when cryptography provider is incorrectly initialized.
+     * @throws GenericCryptoException Throwh when key derivation fails.
      */
-    public byte[] deriveTransportKey(byte[] serverPrivateKeyBytes, byte[] devicePublicKeyBytes) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException {
+    public byte[] deriveTransportKey(byte[] serverPrivateKeyBytes, byte[] devicePublicKeyBytes) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException, CryptoProviderException, GenericCryptoException {
         // Convert keys from bytes
         PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(serverPrivateKeyBytes);
         PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(devicePublicKeyBytes);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/ServiceError.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/ServiceError.java
@@ -112,6 +112,8 @@ public class ServiceError {
 
     /**
      * Token with given token ID does not exist.
+     *
+     * The error code is obsolete, because the error is handled using regular response instead of an exception.
      */
     public static final String INVALID_TOKEN = "ERR0016";
 
@@ -139,6 +141,16 @@ public class ServiceError {
      * Unsupported encryption mode.
      */
     public static final String UNSUPPORTED_ENCRYPTION_MODE = "ERR0021";
+
+    /**
+     * Generic cryptography error.
+     */
+    public static final String GENERIC_CRYPTOGRAPHY_ERROR = "ERR0022";
+
+    /**
+     * Cryptophy provider is initialized incorrectly.
+     */
+    public static final String INVALID_CRYPTO_PROVIDER = "ERR0023";
 
     public static List<String> allCodes() {
         List<String> list = new ArrayList<>(20);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/ServiceError.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/ServiceError.java
@@ -148,7 +148,7 @@ public class ServiceError {
     public static final String GENERIC_CRYPTOGRAPHY_ERROR = "ERR0022";
 
     /**
-     * Cryptophy provider is initialized incorrectly.
+     * Cryptography provider is initialized incorrectly.
      */
     public static final String INVALID_CRYPTO_PROVIDER = "ERR0023";
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -25,7 +25,6 @@ import io.getlime.security.powerauth.app.server.service.exceptions.GenericServic
 import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.v3.*;
@@ -36,9 +35,6 @@ import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.security.InvalidKeyException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -129,11 +125,11 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request) throws Exception {
+    public GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request) throws GenericServiceException {
         try {
             String userId = request.getUserId();
             Long applicationId = request.getApplicationId();
-            logger.info("GetActivationListForUserRequest received, userId: {}, applicationId: {}", userId, String.valueOf(applicationId));
+            logger.info("GetActivationListForUserRequest received, user ID: {}, application ID: {}", userId, applicationId);
             GetActivationListForUserResponse response = behavior.getActivationServiceBehavior().getActivationList(applicationId, userId);
             logger.info("GetActivationListForUserRequest succeeded");
             return response;
@@ -145,13 +141,16 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request) throws Exception {
+    public GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
-            logger.info("GetActivationStatusRequest received, activationId: {}", activationId);
+            logger.info("GetActivationStatusRequest received, activation ID: {}", activationId);
             GetActivationStatusResponse response = behavior.getActivationServiceBehavior().getActivationStatus(activationId, keyConversionUtilities);
             logger.info("GetActivationStatusResponse succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -161,28 +160,28 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public InitActivationResponse initActivation(InitActivationRequest request) throws Exception {
+    public InitActivationResponse initActivation(InitActivationRequest request) throws GenericServiceException {
         try {
             String userId = request.getUserId();
             Long applicationId = request.getApplicationId();
             Long maxFailedCount = request.getMaxFailureCount();
             Date activationExpireTimestamp = XMLGregorianCalendarConverter.convertTo(request.getTimestampActivationExpire());
-            logger.info("InitActivationRequest received, userId: {}, applicationId: {}", userId, String.valueOf(applicationId));
+            logger.info("InitActivationRequest received, user ID: {}, application ID: {}", userId, applicationId);
             InitActivationResponse response = behavior.getActivationServiceBehavior().initActivation(applicationId, userId, maxFailedCount, activationExpireTimestamp, keyConversionUtilities);
             logger.info("InitActivationRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
-        } catch (InvalidKeySpecException | InvalidKeyException ex) {
+        } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
-            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+            throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
         }
     }
 
     @Override
     @Transactional
-    public PrepareActivationResponse prepareActivation(PrepareActivationRequest request) throws Exception {
+    public PrepareActivationResponse prepareActivation(PrepareActivationRequest request) throws GenericServiceException {
         try {
             String activationCode = request.getActivationCode();
             String applicationKey = request.getApplicationKey();
@@ -190,26 +189,26 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             byte[] mac = BaseEncoding.base64().decode(request.getMac());
             byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
             EciesCryptogram cryptogram = new EciesCryptogram(ephemeralPublicKey, mac, encryptedData);
-            logger.info("PrepareActivationRequest received, activationCode: {}", activationCode);
+            logger.info("PrepareActivationRequest received, activation code: {}", activationCode);
             PrepareActivationResponse response = behavior.getActivationServiceBehavior().prepareActivation(activationCode, applicationKey, cryptogram);
             logger.info("PrepareActivationRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
-        } catch (InvalidKeySpecException | IOException | EciesException ex) {
+        } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
-            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+            throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
         }
     }
 
     @Override
     @Transactional
-    public CreateActivationResponse createActivation(CreateActivationRequest request) throws Exception {
+    public CreateActivationResponse createActivation(CreateActivationRequest request) throws GenericServiceException {
         throw new IllegalStateException("Not implemented yet.");
     }
 
-    private VerifySignatureResponse verifySignatureImplNonTransaction(VerifySignatureRequest request, KeyValueMap additionalInfo) throws Exception {
+    private VerifySignatureResponse verifySignatureImplNonTransaction(VerifySignatureRequest request, KeyValueMap additionalInfo) throws GenericServiceException {
 
         // Get request data
         String activationId = request.getActivationId();
@@ -228,12 +227,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public VerifySignatureResponse verifySignature(VerifySignatureRequest request) throws Exception {
+    public VerifySignatureResponse verifySignature(VerifySignatureRequest request) throws GenericServiceException {
         try {
-            logger.info("VerifySignatureRequest received, activationId: {}", request.getActivationId());
+            logger.info("VerifySignatureRequest received, activation ID: {}", request.getActivationId());
             VerifySignatureResponse response = this.verifySignatureImplNonTransaction(request, null);
             logger.info("VerifySignatureRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -242,54 +244,57 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws Exception {
+    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
             String data = request.getData();
-            logger.info("CreatePersonalizedOfflineSignaturePayloadRequest received, activationId: {}", activationId);
+            logger.info("CreatePersonalizedOfflineSignaturePayloadRequest received, activation ID: {}", activationId);
             CreatePersonalizedOfflineSignaturePayloadResponse response = behavior.getSignatureServiceBehavior().createPersonalizedOfflineSignaturePayload(activationId, data, keyConversionUtilities);
             logger.info("CreatePersonalizedOfflineSignaturePayloadRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
         } catch (Exception ex) {
-            logger.error(ex.getMessage(), ex);
-            throw new GenericServiceException(ServiceError.UNABLE_TO_COMPUTE_SIGNATURE, ex.getMessage(), ex.getLocalizedMessage());
+            logger.error("Unknown error occurred", ex);
+            throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
         }
     }
 
     @Override
     @Transactional
-    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws Exception {
+    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws GenericServiceException {
         try {
             long applicationId = request.getApplicationId();
             String data = request.getData();
-            logger.info("CreateNonPersonalizedOfflineSignaturePayloadRequest received, applicationId: {}", String.valueOf(applicationId));
+            logger.info("CreateNonPersonalizedOfflineSignaturePayloadRequest received, application ID: {}", applicationId);
             CreateNonPersonalizedOfflineSignaturePayloadResponse response = behavior.getSignatureServiceBehavior().createNonPersonalizedOfflineSignaturePayload(applicationId, data, keyConversionUtilities);
             logger.info("CreateNonPersonalizedOfflineSignaturePayloadRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
         } catch (Exception ex) {
-            logger.error(ex.getMessage(), ex);
-            throw new GenericServiceException(ServiceError.UNABLE_TO_COMPUTE_SIGNATURE, ex.getMessage(), ex.getLocalizedMessage());
+            logger.error("Unknown error occurred", ex);
+            throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
         }
     }
 
     @Override
     @Transactional
-    public VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request) throws Exception {
+    public VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request) throws GenericServiceException {
         try {
             final String activationId = request.getActivationId();
             final String data = request.getData();
             final String signature = request.getSignature();
             final SignatureType signatureType = request.getSignatureType();
-            logger.info("VerifyOfflineSignatureRequest received, activationId: {}", activationId);
+            logger.info("VerifyOfflineSignatureRequest received, activation ID: {}", activationId);
             VerifyOfflineSignatureResponse response = behavior.getSignatureServiceBehavior().verifyOfflineSignature(activationId, signatureType, signature, data, keyConversionUtilities);
             logger.info("VerifyOfflineSignatureRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -298,15 +303,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CommitActivationResponse commitActivation(CommitActivationRequest request) throws Exception {
+    public CommitActivationResponse commitActivation(CommitActivationRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
-            logger.info("CommitActivationRequest received, activationId: {}", activationId);
+            logger.info("CommitActivationRequest received, activation ID: {}", activationId);
             CommitActivationResponse response = behavior.getActivationServiceBehavior().commitActivation(activationId);
             logger.info("CommitActivationRequest succeeded", request.getActivationId());
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
@@ -316,13 +321,16 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public RemoveActivationResponse removeActivation(RemoveActivationRequest request) throws Exception {
+    public RemoveActivationResponse removeActivation(RemoveActivationRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
-            logger.info("RemoveActivationRequest received, activationId: {}", activationId);
+            logger.info("RemoveActivationRequest received, activation ID: {}", activationId);
             RemoveActivationResponse response = behavior.getActivationServiceBehavior().removeActivation(activationId);
             logger.info("RemoveActivationRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -331,16 +339,16 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public BlockActivationResponse blockActivation(BlockActivationRequest request) throws Exception {
+    public BlockActivationResponse blockActivation(BlockActivationRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
             String reason = request.getReason();
-            logger.info("BlockActivationRequest received, activationId: {}", activationId);
+            logger.info("BlockActivationRequest received, activation ID: {}", activationId);
             BlockActivationResponse response = behavior.getActivationServiceBehavior().blockActivation(activationId, reason);
             logger.info("BlockActivationRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
@@ -350,15 +358,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public UnblockActivationResponse unblockActivation(UnblockActivationRequest request) throws Exception {
+    public UnblockActivationResponse unblockActivation(UnblockActivationRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
-            logger.info("UnblockActivationRequest received, activationId: {}", activationId);
+            logger.info("UnblockActivationRequest received, activation ID: {}", activationId);
             UnblockActivationResponse response = behavior.getActivationServiceBehavior().unblockActivation(activationId);
             logger.info("UnblockActivationRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
@@ -369,7 +377,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public VaultUnlockResponse vaultUnlock(VaultUnlockRequest request) throws Exception {
+    public VaultUnlockResponse vaultUnlock(VaultUnlockRequest request) throws GenericServiceException {
         try {
             // Get request data
             final String activationId = request.getActivationId();
@@ -381,12 +389,13 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
             byte[] mac = BaseEncoding.base64().decode(request.getMac());
 
-            logger.info("VaultUnlockRequest received, activationId: {}", activationId);
+            logger.info("VaultUnlockRequest received, activation ID: {}", activationId);
 
             // Reject 1FA signatures
             if (signatureType.equals(SignatureType.BIOMETRY)
                     || signatureType.equals(SignatureType.KNOWLEDGE)
                     || signatureType.equals(SignatureType.POSSESSION)) {
+                logger.warn("Invalid signature type: {}", signatureType);
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_SIGNATURE);
             }
 
@@ -398,7 +407,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             logger.info("VaultUnlockRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {
-            logger.error("Unknown error occurred", ex);
+            // already logged
             throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
@@ -408,17 +417,20 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request) throws Exception {
+    public VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
             String signedData = request.getData();
             String signature  = request.getSignature();
-            logger.info("VerifyECDSASignatureRequest received, activationId: {}", activationId);
+            logger.info("VerifyECDSASignatureRequest received, activation ID: {}", activationId);
             boolean matches = behavior.getAsymmetricSignatureServiceBehavior().verifyECDSASignature(activationId, signedData, signature, keyConversionUtilities);
             VerifyECDSASignatureResponse response = new VerifyECDSASignatureResponse();
             response.setSignatureValid(matches);
             logger.info("VerifyECDSASignatureRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -427,7 +439,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request) throws Exception {
+    public SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request) throws GenericServiceException {
         try {
 
             String userId = request.getUserId();
@@ -435,7 +447,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             Date startingDate = XMLGregorianCalendarConverter.convertTo(request.getTimestampFrom());
             Date endingDate = XMLGregorianCalendarConverter.convertTo(request.getTimestampTo());
 
-            logger.info("SignatureAuditRequest received, userId: {}, applicationId: {}", userId, String.valueOf(applicationId));
+            logger.info("SignatureAuditRequest received, user ID: {}, application ID: {}", userId, applicationId);
             SignatureAuditResponse response = behavior.getAuditingServiceBehavior().getSignatureAuditLog(userId, applicationId, startingDate, endingDate);
             logger.info("SignatureAuditRequest succeeded");
             return response;
@@ -448,12 +460,13 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     }
 
     @Override
-    public ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request) throws Exception {
+    @Transactional
+    public ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request) throws GenericServiceException {
         try {
             String activationId = request.getActivationId();
             Date startingDate = XMLGregorianCalendarConverter.convertTo(request.getTimestampFrom());
             Date endingDate = XMLGregorianCalendarConverter.convertTo(request.getTimestampTo());
-            logger.info("ActivationHistoryRequest received, activationId: {}", activationId);
+            logger.info("ActivationHistoryRequest received, activation ID: {}", activationId);
             ActivationHistoryResponse response = behavior.getActivationHistoryServiceBehavior().getActivationHistory(activationId, startingDate, endingDate);
             logger.info("ActivationHistoryRequest succeeded");
             return response;
@@ -465,7 +478,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetApplicationListResponse getApplicationList(GetApplicationListRequest request) throws Exception {
+    public GetApplicationListResponse getApplicationList(GetApplicationListRequest request) throws GenericServiceException {
         try {
             logger.info("GetApplicationListRequest received");
             GetApplicationListResponse response = behavior.getApplicationServiceBehavior().getApplicationList();
@@ -479,12 +492,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetApplicationDetailResponse getApplicationDetail(GetApplicationDetailRequest request) throws Exception {
+    public GetApplicationDetailResponse getApplicationDetail(GetApplicationDetailRequest request) throws GenericServiceException {
         try {
-            logger.info("GetApplicationDetailRequest received, applicationId: {}", String.valueOf(request.getApplicationId()));
+            logger.info("GetApplicationDetailRequest received, application ID: {}", request.getApplicationId());
             GetApplicationDetailResponse response = behavior.getApplicationServiceBehavior().getApplicationDetail(request.getApplicationId());
             logger.info("GetApplicationDetailRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -493,25 +509,32 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request) throws Exception {
+    public LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request) throws GenericServiceException {
         try {
             logger.info("LookupApplicationByAppKeyRequest received");
             LookupApplicationByAppKeyResponse response = behavior.getApplicationServiceBehavior().lookupApplicationByAppKey(request.getApplicationKey());
             logger.info("LookupApplicationByAppKeyRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
-            throw localizationProvider.buildExceptionForCode(ServiceError.NO_APPLICATION_ID);
+            logger.error("Unknown error occurred", ex);
+            throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
         }
     }
 
     @Override
     @Transactional
-    public CreateApplicationResponse createApplication(CreateApplicationRequest request) throws Exception {
+    public CreateApplicationResponse createApplication(CreateApplicationRequest request) throws GenericServiceException {
         try {
-            logger.info("CreateApplicationRequest received, applicationName: {}", request.getApplicationName());
+            logger.info("CreateApplicationRequest received, application name: {}", request.getApplicationName());
             CreateApplicationResponse response = behavior.getApplicationServiceBehavior().createApplication(request.getApplicationName(), keyConversionUtilities);
             logger.info("CreateApplicationRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -520,12 +543,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request) throws Exception {
+    public CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request) throws GenericServiceException {
         try {
-            logger.info("CreateApplicationVersionRequest received, applicationId: {}, applicationVersionName: {}", String.valueOf(request.getApplicationId()), request.getApplicationVersionName());
+            logger.info("CreateApplicationVersionRequest received, application ID: {}, application version name: {}", request.getApplicationId(), request.getApplicationVersionName());
             CreateApplicationVersionResponse response = behavior.getApplicationServiceBehavior().createApplicationVersion(request.getApplicationId(), request.getApplicationVersionName());
             logger.info("CreateApplicationVersionRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -534,12 +560,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public UnsupportApplicationVersionResponse unsupportApplicationVersion(UnsupportApplicationVersionRequest request) throws Exception {
+    public UnsupportApplicationVersionResponse unsupportApplicationVersion(UnsupportApplicationVersionRequest request) throws GenericServiceException {
         try {
-            logger.info("UnsupportApplicationVersionRequest received, applicationVersionId: {}", request.getApplicationVersionId());
+            logger.info("UnsupportApplicationVersionRequest received, application version ID: {}", request.getApplicationVersionId());
             UnsupportApplicationVersionResponse response = behavior.getApplicationServiceBehavior().unsupportApplicationVersion(request.getApplicationVersionId());
             logger.info("UnsupportApplicationVersionRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -548,12 +577,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public SupportApplicationVersionResponse supportApplicationVersion(SupportApplicationVersionRequest request) throws Exception {
+    public SupportApplicationVersionResponse supportApplicationVersion(SupportApplicationVersionRequest request) throws GenericServiceException {
         try {
-            logger.info("SupportApplicationVersionRequest received, applicationVersionId: {}", request.getApplicationVersionId());
+            logger.info("SupportApplicationVersionRequest received, application version ID: {}", request.getApplicationVersionId());
             SupportApplicationVersionResponse response = behavior.getApplicationServiceBehavior().supportApplicationVersion(request.getApplicationVersionId());
             logger.info("SupportApplicationVersionRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -562,7 +594,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CreateIntegrationResponse createIntegration(CreateIntegrationRequest request) throws Exception {
+    public CreateIntegrationResponse createIntegration(CreateIntegrationRequest request) throws GenericServiceException {
         try {
             logger.info("CreateIntegrationRequest received, name: {}", request.getName());
             CreateIntegrationResponse response = behavior.getIntegrationBehavior().createIntegration(request);
@@ -576,7 +608,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetIntegrationListResponse getIntegrationList() throws Exception {
+    public GetIntegrationListResponse getIntegrationList() throws GenericServiceException {
         try {
             logger.info("GetIntegrationListRequest received");
             GetIntegrationListResponse response = behavior.getIntegrationBehavior().getIntegrationList();
@@ -590,7 +622,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public RemoveIntegrationResponse removeIntegration(RemoveIntegrationRequest request) throws Exception {
+    public RemoveIntegrationResponse removeIntegration(RemoveIntegrationRequest request) throws GenericServiceException {
         try {
             logger.info("RemoveIntegrationRequest received, id: {}", request.getId());
             RemoveIntegrationResponse response = behavior.getIntegrationBehavior().removeIntegration(request);
@@ -604,12 +636,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request) throws Exception {
+    public CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request) throws GenericServiceException {
         try {
             logger.info("CreateCallbackUrlRequest received, name: {}", request.getName());
             CreateCallbackUrlResponse response = behavior.getCallbackUrlBehavior().createCallbackUrl(request);
             logger.info("CreateCallbackUrlRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -618,9 +653,9 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetCallbackUrlListResponse getCallbackUrlList(GetCallbackUrlListRequest request) throws Exception {
+    public GetCallbackUrlListResponse getCallbackUrlList(GetCallbackUrlListRequest request) throws GenericServiceException {
         try {
-            logger.info("GetCallbackUrlListRequest received, applicationId: {}", String.valueOf(request.getApplicationId()));
+            logger.info("GetCallbackUrlListRequest received, application ID: {}", request.getApplicationId());
             GetCallbackUrlListResponse response = behavior.getCallbackUrlBehavior().getCallbackUrlList(request);
             logger.info("GetCallbackUrlListRequest succeeded");
             return response;
@@ -632,10 +667,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request) throws Exception {
+    public RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request) throws GenericServiceException {
         try {
             logger.info("RemoveCallbackUrlRequest received, id: {}", request.getId());
-            RemoveCallbackUrlResponse response = behavior.getCallbackUrlBehavior().removeIntegration(request);
+            RemoveCallbackUrlResponse response = behavior.getCallbackUrlBehavior().removeCallbackUrl(request);
             logger.info("RemoveCallbackUrlRequest succeeded");
             return response;
         } catch (Exception ex) {
@@ -646,12 +681,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CreateTokenResponse createToken(CreateTokenRequest request) throws Exception {
+    public CreateTokenResponse createToken(CreateTokenRequest request) throws GenericServiceException {
         try {
-            logger.info("CreateTokenRequest received, activationId: {}", request.getActivationId());
+            logger.info("CreateTokenRequest received, activation ID: {}", request.getActivationId());
             CreateTokenResponse response = behavior.getTokenBehavior().createToken(request, keyConversionUtilities);
             logger.info("CreateTokenRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -660,12 +698,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public ValidateTokenResponse validateToken(ValidateTokenRequest request) throws Exception {
+    public ValidateTokenResponse validateToken(ValidateTokenRequest request) throws GenericServiceException {
         try {
-            logger.info("ValidateTokenRequest received, tokenId: {}", request.getTokenId());
+            logger.info("ValidateTokenRequest received, token ID: {}", request.getTokenId());
             ValidateTokenResponse response = behavior.getTokenBehavior().validateToken(request);
             logger.info("ValidateTokenRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -674,9 +715,9 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public RemoveTokenResponse removeToken(RemoveTokenRequest request) throws Exception {
+    public RemoveTokenResponse removeToken(RemoveTokenRequest request) throws GenericServiceException {
         try {
-            logger.info("RemoveTokenRequest received, tokenId: {}", request.getTokenId());
+            logger.info("RemoveTokenRequest received, token ID: {}", request.getTokenId());
             RemoveTokenResponse response = behavior.getTokenBehavior().removeToken(request);
             logger.info("RemoveTokenRequest succeeded");
             return response;
@@ -688,12 +729,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws Exception {
+    public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws GenericServiceException {
         try {
-            logger.info("GetEciesDecryptorRequest received, applicationKey: {}, activationId: {}", new String[]{request.getApplicationKey(), request.getActivationId()});
+            logger.info("GetEciesDecryptorRequest received, application key: {}, activation ID: {}", request.getApplicationKey(), request.getActivationId());
             GetEciesDecryptorResponse response = behavior.getEciesEncryptionBehavior().getEciesDecryptorParameters(request);
             logger.info("GetEciesDecryptorRequest succeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -702,12 +746,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws Exception {
+    public StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws GenericServiceException {
         try {
-            logger.info("StartUpgradeRequest received, applicationKey: {}, activationId: {} ", request.getApplicationKey(), request.getActivationId());
+            logger.info("StartUpgradeRequest received, application key: {}, activation ID: {}", request.getApplicationKey(), request.getActivationId());
             StartUpgradeResponse response = behavior.getUpgradeServiceBehavior().startUpgrade(request);
             logger.info("StartUpgradeRequest succeeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());
@@ -716,12 +763,15 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request) throws Exception {
+    public CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request) throws GenericServiceException {
         try {
-            logger.info("CommitUpgradeRequest received, applicationKey: {}, activationId: {} ", request.getApplicationKey(), request.getActivationId());
+            logger.info("CommitUpgradeRequest received, application key: {}, activation ID: {}", request.getApplicationKey(), request.getActivationId());
             CommitUpgradeResponse response = behavior.getUpgradeServiceBehavior().commitUpgrade(request);
             logger.info("CommitUpgradeRequest succeeeded");
             return response;
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
         } catch (Exception ex) {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage(), ex.getLocalizedMessage());


### PR DESCRIPTION
This pull request contains following improvements:
- Fix #208: Crypto 3.0: Handle new exceptions from powerauth-crypto
- Unified error handling for all service behaviors (log messages should appear only once)
- Finished migration to SLF4J logging (minor formatting changes)
- Additional logging for unexpected states
- Separation of errors, warnings and informational messages