### PR TITLE
Fix #186: Crypto 3.0: Custom activation

### DIFF
--- a/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
@@ -276,53 +276,29 @@ public class PowerAuthServiceClient {
     /**
      * Call the createActivation method of the PowerAuth 3.0 Server SOAP interface.
      * @param userId User ID.
-     * @param applicationKey Application key of a given application.
-     * @param identity Identity fingerprint used during activation.
-     * @param activationName Name of this activation.
-     * @param activationNonce Activation nonce.
-     * @param applicationSignature Signature proving a correct application is sending the data.
-     * @param cDevicePublicKey Device public key encrypted with activation OTP.
-     * @param ephemeralPublicKey Ephemeral public key used for one-time object transfer.
-     * @param extras Additional, application specific information.
+     * @param timestampActivationExpire Expiration timestamp for activation (optional).
+     * @param maxFailureCount Maximum failure count (optional).
+     * @param applicationKey Application key.
+     * @param ephemeralPublicKey Ephemeral public key for ECIES.
+     * @param encryptedData Encrypted data for ECIES.
+     * @param mac Mac of key and data for ECIES.
      * @return {@link io.getlime.powerauth.soap.v3.PowerAuthPortV3ServiceStub.CreateActivationResponse}
      * @throws RemoteException In case of a business logic error.
      */
-    public PowerAuthPortV3ServiceStub.CreateActivationResponse createActivation(String applicationKey, String userId, String identity, String activationName, String activationNonce, String ephemeralPublicKey, String cDevicePublicKey, String extras, String applicationSignature) throws RemoteException {
-        return this.createActivation(
-                applicationKey,
-                userId,
-                null,
-                null,
-                identity,
-                "00000-00000",
-                activationName,
-                activationNonce,
-                ephemeralPublicKey,
-                cDevicePublicKey,
-                extras,
-                applicationSignature
-        );
-    }
-
-    /**
-     * Call the createActivation method of the PowerAuth 3.0 Server SOAP interface.
-     * @param userId User ID.
-     * @param maxFailureCount Maximum failure count.
-     * @param timestampActivationExpire Timestamp this activation should expire.
-     * @param applicationKey Application key of a given application.
-     * @param identity Identity fingerprint used during activation.
-     * @param activationOtp Activation OTP.
-     * @param activationName Name of this activation.
-     * @param activationNonce Activation nonce.
-     * @param applicationSignature Signature proving a correct application is sending the data.
-     * @param cDevicePublicKey Device public key encrypted with activation OTP.
-     * @param ephemeralPublicKey Ephemeral public key used for one-time object transfer.
-     * @param extras Additional, application specific information.
-     * @return {@link io.getlime.powerauth.soap.v3.PowerAuthPortV3ServiceStub.CreateActivationResponse}
-     * @throws RemoteException In case of a business logic error.
-     */
-    public PowerAuthPortV3ServiceStub.CreateActivationResponse createActivation(String applicationKey, String userId, Long maxFailureCount, Date timestampActivationExpire, String identity, String activationOtp, String activationName, String activationNonce, String ephemeralPublicKey, String cDevicePublicKey, String extras, String applicationSignature) throws RemoteException {
-        throw new IllegalStateException("Not implemented yet.");
+    public PowerAuthPortV3ServiceStub.CreateActivationResponse createActivation(String userId, Date timestampActivationExpire, Long maxFailureCount, String applicationKey, String ephemeralPublicKey, String encryptedData, String mac) throws RemoteException {
+        PowerAuthPortV3ServiceStub.CreateActivationRequest request = new PowerAuthPortV3ServiceStub.CreateActivationRequest();
+        request.setUserId(userId);
+        if (timestampActivationExpire != null) {
+            request.setTimestampActivationExpire(calendarWithDate(timestampActivationExpire));
+        }
+        if (maxFailureCount != null) {
+            request.setMaxFailureCount(maxFailureCount);
+        }
+        request.setApplicationKey(applicationKey);
+        request.setEphemeralPublicKey(ephemeralPublicKey);
+        request.setEncryptedData(encryptedData);
+        request.setMac(mac);
+        return this.createActivation(request);
     }
 
     /**

--- a/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
@@ -156,51 +156,28 @@ public class PowerAuthServiceClient extends WebServiceGatewaySupport {
     /**
      * Call the createActivation method of the PowerAuth 3.0 Server SOAP interface.
      * @param userId User ID.
-     * @param applicationKey Application key of a given application.
-     * @param identity Identity fingerprint used during activation.
-     * @param activationName Name of this activation.
-     * @param activationNonce Activation nonce.
-     * @param applicationSignature Signature proving a correct application is sending the data.
-     * @param cDevicePublicKey Device public key encrypted with activation OTP.
-     * @param ephemeralPublicKey Ephemeral public key used for one-time object transfer.
-     * @param extras Additional, application specific information.
+     * @param timestampActivationExpire Expiration timestamp for activation (optional).
+     * @param maxFailureCount Maximum failure count (optional).
+     * @param applicationKey Application key.
+     * @param ephemeralPublicKey Ephemeral public key for ECIES.
+     * @param encryptedData Encrypted data for ECIES.
+     * @param mac Mac of key and data for ECIES.
      * @return {@link CreateActivationResponse}
      */
-    public CreateActivationResponse createActivation(String applicationKey, String userId, String identity, String activationName, String activationNonce, String ephemeralPublicKey, String cDevicePublicKey, String extras, String applicationSignature) {
-        return this.createActivation(
-                applicationKey,
-                userId,
-                null,
-                null,
-                identity,
-                "00000-00000",
-                activationName,
-                activationNonce,
-                ephemeralPublicKey,
-                cDevicePublicKey,
-                extras,
-                applicationSignature
-        );
-    }
-
-    /**
-     * Call the createActivation method of the PowerAuth 3.0 Server SOAP interface.
-     * @param userId User ID.
-     * @param maxFailureCount Maximum failure count.
-     * @param timestampActivationExpire Timestamp this activation should expire.
-     * @param applicationKey Application key of a given application.
-     * @param identity Identity fingerprint used during activation.
-     * @param activationOtp Activation OTP.
-     * @param activationName Name of this activation.
-     * @param activationNonce Activation nonce.
-     * @param applicationSignature Signature proving a correct application is sending the data.
-     * @param cDevicePublicKey Device public key encrypted with activation OTP.
-     * @param ephemeralPublicKey Ephemeral public key.
-     * @param extras Additional, application specific information.
-     * @return {@link CreateActivationResponse}
-     */
-    public CreateActivationResponse createActivation(String applicationKey, String userId, Long maxFailureCount, Date timestampActivationExpire, String identity, String activationOtp, String activationName, String activationNonce, String ephemeralPublicKey, String cDevicePublicKey, String extras, String applicationSignature) {
-        throw new IllegalStateException("Not implemented yet");
+    public CreateActivationResponse createActivation(String userId, Date timestampActivationExpire, Long maxFailureCount, String applicationKey, String ephemeralPublicKey, String encryptedData, String mac) {
+        CreateActivationRequest request = new CreateActivationRequest();
+        request.setUserId(userId);
+        if (timestampActivationExpire != null) {
+            request.setTimestampActivationExpire(calendarWithDate(timestampActivationExpire));
+        }
+        if (maxFailureCount != null) {
+            request.setMaxFailureCount(maxFailureCount);
+        }
+        request.setApplicationKey(applicationKey);
+        request.setEphemeralPublicKey(ephemeralPublicKey);
+        request.setEncryptedData(encryptedData);
+        request.setMac(mac);
+        return createActivation(request);
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
@@ -196,14 +196,14 @@ public class ActivationServiceBehavior {
             final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
 
             ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-            // if there is no such application, exit
+            // If there is no such activation version or activation version is unsupported, exit
             if (applicationVersion == null || !applicationVersion.getSupported()) {
                 logger.warn("Application version is incorrect, application key: {}", applicationKey);
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
             }
 
             ApplicationEntity application = applicationVersion.getApplication();
-            // if there is no such application, exit
+            // If there is no such application, exit
             if (application == null) {
                 logger.warn("Application does not exist, application key: {}", applicationKey);
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
@@ -360,14 +360,14 @@ public class ActivationServiceBehavior {
             final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
 
             ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-            // if there is no such application, exit
+            // If there is no such activation version or activation version is unsupported, exit
             if (applicationVersion == null || !applicationVersion.getSupported()) {
                 logger.warn("Application version is incorrect, application key: {}", applicationKey);
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
             }
 
             ApplicationEntity application = applicationVersion.getApplication();
-            // if there is no such application, exit
+            // If there is no such application, exit
             if (application == null) {
                 logger.warn("Application is incorrect, application key: {}", applicationKey);
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -755,14 +755,14 @@ public class ActivationServiceBehavior {
             final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
 
             ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-            // if there is no such application, exit
+            // If there is no such activation version or activation version is unsupported, exit
             if (applicationVersion == null || !applicationVersion.getSupported()) {
                 logger.warn("Application version is incorrect, application key: {}", applicationKey);
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
             }
 
             ApplicationEntity application = applicationVersion.getApplication();
-            // if there is no such application, exit
+            // If there is no such application, exit
             if (application == null) {
                 logger.warn("Application is incorrect, application key: {}", applicationKey);
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -175,14 +175,14 @@ public class ActivationServiceBehavior {
     }
 
     /**
-     * Validate activation in prepare activation step: it should be in CREATED state, it should be linked to correct
+     * Validate activation in prepare or create activation step: it should be in CREATED state, it should be linked to correct
      * application and the activation code should have valid length.
      *
      * @param activation Activation used in prepare activation step.
      * @param application Application used in prepare activation step.
      * @throws GenericServiceException In case activation state is invalid.
      */
-    private void validateActivationInPrepareStep(ActivationRecordEntity activation, ApplicationEntity application) throws GenericServiceException {
+    private void validateCreatedActivation(ActivationRecordEntity activation, ApplicationEntity application) throws GenericServiceException {
         // If there is no such activation or application does not match the activation application, fail validation
         if (activation == null
                 || !ActivationStatus.CREATED.equals(activation.getActivationStatus())
@@ -437,13 +437,13 @@ public class ActivationServiceBehavior {
      *
      * @param applicationId             Application ID
      * @param userId                    User ID
-     * @param maxFailedCount            Maximum failed attempt count (5)
+     * @param maxFailureCount            Maximum failed attempt count (5)
      * @param activationExpireTimestamp Timestamp after which activation can no longer be completed
      * @param keyConversionUtilities    Utility class for key conversion
      * @return Response with activation initialization data
      * @throws GenericServiceException If invalid values are provided.
      */
-    public InitActivationResponse initActivation(Long applicationId, String userId, Long maxFailedCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
+    public InitActivationResponse initActivation(Long applicationId, String userId, Long maxFailureCount, Date activationExpireTimestamp, CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
         try {
             // Generate timestamp in advance
             Date timestamp = new Date();
@@ -465,7 +465,7 @@ public class ActivationServiceBehavior {
             final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
 
             // Get number of max attempts from request or from constants, if not provided
-            Long maxAttempt = maxFailedCount;
+            Long maxAttempt = maxFailureCount;
             if (maxAttempt == null) {
                 maxAttempt = powerAuthServiceConfiguration.getSignatureMaxFailedAttempts();
             }
@@ -657,7 +657,7 @@ public class ActivationServiceBehavior {
             }
 
             // Validate that the activation is in correct state for the prepare step
-            validateActivationInPrepareStep(activation, application);
+            validateCreatedActivation(activation, application);
 
             // Extract the device public key from request
             byte[] devicePublicKeyBytes = BaseEncoding.base64().decode(request.getDevicePublicKey());
@@ -676,6 +676,7 @@ public class ActivationServiceBehavior {
 
             // Update and persist the activation record
             activation.setActivationStatus(ActivationStatus.OTP_USED);
+            // The device public key is converted back to bytes and base64 encoded so that the key is saved in normalized form
             activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversion.convertPublicKeyToBytes(devicePublicKey)));
             activation.setActivationName(request.getActivationName());
             activation.setExtras(request.getExtras());
@@ -729,38 +730,144 @@ public class ActivationServiceBehavior {
      * </ul>
      *
      * @param userId                         User ID
-     * @param maxFailedCount                 Maximum failed attempt count (5)
      * @param activationExpireTimestamp      Timestamp after which activation can no longer be completed
-     * @param identity                       A string representing the provided identity
-     * @param activationOtp                  Activation OTP parameter
-     * @param activationNonceBase64          Activation nonce encoded as Base64
-     * @param clientEphemeralPublicKeyBase64 Client ephemeral public key encoded as Base64
-     * @param cDevicePublicKeyBase64         Encrypted device public key encoded as Base64
-     * @param activationName                 Activation name
-     * @param extras                         Extra parameter
+     * @param maxFailureCount                Maximum failed attempt count (default = 5)
      * @param applicationKey                 Application key
-     * @param applicationSignature           Application signature
+     * @param eciesCryptogram                ECIES cryptogram
      * @param keyConversionUtilities         Utility class for key conversion
-     * @return Prepared activation information
-     * @throws GenericServiceException      In case invalid data is provided
-     * @throws InvalidKeySpecException      If invalid key was provided
-     * @throws InvalidKeyException          If invalid key was provided
+     * @return ECIES encrypted activation information
+     * @throws GenericServiceException       In case create activation fails
      */
     public CreateActivationResponse createActivation(
-            String applicationKey,
             String userId,
-            Long maxFailedCount,
             Date activationExpireTimestamp,
-            String identity,
-            String activationOtp,
-            String activationNonceBase64,
-            String clientEphemeralPublicKeyBase64,
-            String cDevicePublicKeyBase64,
-            String activationName,
-            String extras,
-            String applicationSignature,
-            CryptoProviderUtil keyConversionUtilities) throws GenericServiceException, InvalidKeySpecException, InvalidKeyException {
-        throw new IllegalStateException("Not implemented yet.");
+            Long maxFailureCount,
+            String applicationKey,
+            EciesCryptogram eciesCryptogram,
+            CryptoProviderUtil keyConversionUtilities) throws GenericServiceException {
+        try {
+            // Get current timestamp
+            Date timestamp = new Date();
+
+            // Get required repositories
+            final ActivationRepository activationRepository = repositoryCatalogue.getActivationRepository();
+            final MasterKeyPairRepository masterKeyPairRepository = repositoryCatalogue.getMasterKeyPairRepository();
+            final ApplicationVersionRepository applicationVersionRepository = repositoryCatalogue.getApplicationVersionRepository();
+
+            ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
+            // if there is no such application, exit
+            if (applicationVersion == null || !applicationVersion.getSupported()) {
+                logger.warn("Application version is incorrect, application key: {}", applicationKey);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+            }
+
+            ApplicationEntity application = applicationVersion.getApplication();
+            // if there is no such application, exit
+            if (application == null) {
+                logger.warn("Application is incorrect, application key: {}", applicationKey);
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+            }
+
+            // Create an activation record and obtain the activation database record
+            InitActivationResponse initResponse = this.initActivation(application.getId(), userId, maxFailureCount, activationExpireTimestamp, keyConversionUtilities);
+            String activationId = initResponse.getActivationId();
+            ActivationRecordEntity activation = activationRepository.findActivation(activationId);
+
+            // Make sure to deactivate the activation if it is expired
+            if (activation != null) {
+                deactivatePendingActivation(timestamp, activation);
+            }
+
+            validateCreatedActivation(activation, application);
+
+            // Get master server private key
+            MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
+            if (masterKeyPairEntity == null) {
+                logger.error("Missing key pair for application ID: {}", application.getId());
+                throw localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
+            }
+
+            String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
+            PrivateKey privateKey = keyConversion.convertBytesToPrivateKey(BaseEncoding.base64().decode(masterPrivateKeyBase64));
+
+            // Get application secret
+            byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+
+            // Get ecies decryptor
+            EciesDecryptor eciesDecryptor = eciesFactory.getEciesDecryptorForApplication((ECPrivateKey) privateKey, applicationSecret, EciesSharedInfo1.ACTIVATION_LAYER_2);
+
+            // Decrypt activation data
+            byte[] activationData = eciesDecryptor.decryptRequest(eciesCryptogram);
+
+            // Convert JSON data to activation layer 2 request object
+            ActivationLayer2Request request;
+            try {
+                request = objectMapper.readValue(activationData, ActivationLayer2Request.class);
+            } catch (IOException ex) {
+                logger.warn("Invalid activation request, activation ID: {}", activationId);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+            }
+
+            // Extract the device public key from request
+            byte[] devicePublicKeyBytes = BaseEncoding.base64().decode(request.getDevicePublicKey());
+            PublicKey devicePublicKey = null;
+
+            try {
+                devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
+            } catch (InvalidKeySpecException ex) {
+                handleInvalidPublicKey(activation);
+            }
+
+            // Initialize hash based counter
+            HashBasedCounter counter = new HashBasedCounter();
+            byte[] ctrData = counter.init();
+            String ctrDataBase64 = BaseEncoding.base64().encode(ctrData);
+
+            // Update and persist the activation record
+            activation.setActivationStatus(ActivationStatus.OTP_USED);
+            // The device public key is converted back to bytes and base64 encoded so that the key is saved in normalized form
+            activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversion.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setActivationName(request.getActivationName());
+            activation.setExtras(request.getExtras());
+            // PowerAuth protocol version 3.0 uses 0x3 as version in activation status
+            activation.setVersion(3);
+            // Set initial counter data
+            activation.setCtrDataBase64(ctrDataBase64);
+            activationRepository.save(activation);
+            activationHistoryServiceBehavior.logActivationStatusChange(activation);
+            callbackUrlBehavior.notifyCallbackListeners(activation.getApplication().getId(), activation.getActivationId());
+
+            // Generate activation layer 2 response
+            ActivationLayer2Response response = new ActivationLayer2Response();
+            response.setActivationId(activation.getActivationId());
+            response.setCtrData(ctrDataBase64);
+            response.setServerPublicKey(activation.getServerPublicKeyBase64());
+            byte[] responseData = objectMapper.writeValueAsBytes(response);
+
+            // Encrypt response data
+            EciesCryptogram responseCryptogram = eciesDecryptor.encryptResponse(responseData);
+            String encryptedData = BaseEncoding.base64().encode(responseCryptogram.getEncryptedData());
+            String mac = BaseEncoding.base64().encode(responseCryptogram.getMac());
+
+            // Generate encrypted response
+            CreateActivationResponse encryptedResponse = new CreateActivationResponse();
+            encryptedResponse.setActivationId(activation.getActivationId());
+            encryptedResponse.setEncryptedData(encryptedData);
+            encryptedResponse.setMac(mac);
+            return encryptedResponse;
+        } catch (InvalidKeySpecException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (EciesException | JsonProcessingException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        } catch (GenericCryptoException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        } catch (CryptoProviderException ex) {
+            logger.error(ex.getMessage(), ex);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
+        }
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/ServiceError.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/ServiceError.java
@@ -152,6 +152,11 @@ public class ServiceError {
      */
     public static final String INVALID_CRYPTO_PROVIDER = "ERR0023";
 
+    /**
+     * Invalid request error.
+     */
+    public static final String INVALID_REQUEST = "ERR0024";
+
     public static List<String> allCodes() {
         List<String> list = new ArrayList<>(20);
         list.add(UNKNOWN_ERROR);
@@ -176,6 +181,9 @@ public class ServiceError {
         list.add(UNABLE_TO_GENERATE_TOKEN);
         list.add(MISSING_MASTER_DB_ENCRYPTION_KEY);
         list.add(UNSUPPORTED_ENCRYPTION_MODE);
+        list.add(GENERIC_CRYPTOGRAPHY_ERROR);
+        list.add(INVALID_CRYPTO_PROVIDER);
+        list.add(INVALID_REQUEST);
         return list;
     }
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v2/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v2/PowerAuthServiceImpl.java
@@ -74,6 +74,11 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public PrepareActivationResponse prepareActivation(PrepareActivationRequest request) throws Exception {
+        if (request.getActivationIdShort() == null || request.getActivationNonce() == null || request.getEncryptedDevicePublicKey() == null
+            || request.getActivationName() == null || request.getEphemeralPublicKey() == null || request.getApplicationKey() == null || request.getApplicationSignature() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             // Get request parameters
             String activationIdShort = request.getActivationIdShort();
@@ -100,6 +105,12 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateActivationResponse createActivation(CreateActivationRequest request) throws Exception {
+        if (request.getApplicationKey() == null || request.getUserId() == null || request.getActivationOtp() == null || request.getActivationNonce() == null || request.getEncryptedDevicePublicKey() == null
+                || request.getActivationName() == null || request.getEphemeralPublicKey() == null || request.getApplicationKey() == null || request.getApplicationSignature() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        // The maxFailedCount and activationExpireTimestamp values can be null, in this case default values are used
         try {
             // Get request parameters
             String applicationKey = request.getApplicationKey();
@@ -144,6 +155,12 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public VaultUnlockResponse vaultUnlock(VaultUnlockRequest request) throws Exception {
+        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getSignature() == null
+                || request.getSignatureType() == null || request.getData() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        // Vault unlock reason can be null, in this case unspecified reason is used
         try {
 
             // Get request data
@@ -199,6 +216,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public GetPersonalizedEncryptionKeyResponse generateE2EPersonalizedEncryptionKey(GetPersonalizedEncryptionKeyRequest request) throws Exception {
+        if (request.getActivationId() == null || request.getSessionIndex() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("GetPersonalizedEncryptionKeyRequest received, activation ID: {}", request.getActivationId());
             GetPersonalizedEncryptionKeyResponse response = behavior.v2().getEncryptionServiceBehavior().generateEncryptionKeyForActivation(
@@ -220,6 +241,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public GetNonPersonalizedEncryptionKeyResponse generateE2ENonPersonalizedEncryptionKey(GetNonPersonalizedEncryptionKeyRequest request) throws Exception {
+        if (request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getSessionIndex() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("GetNonPersonalizedEncryptionKeyRequest received");
             GetNonPersonalizedEncryptionKeyResponse response = behavior.v2().getEncryptionServiceBehavior().generateNonPersonalizedEncryptionKeyForApplication(
@@ -242,6 +267,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateTokenResponse createToken(CreateTokenRequest request) throws Exception {
+        if (request.getActivationId() == null || request.getEphemeralPublicKey() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CreateTokenRequest received, activation ID: {}", request.getActivationId());
             CreateTokenResponse response = behavior.v2().getTokenBehavior().createToken(request, keyConversionUtilities);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -126,6 +126,11 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request) throws GenericServiceException {
+        if (request.getUserId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        // The applicationId can be null, in this case all applications are used
         try {
             String userId = request.getUserId();
             Long applicationId = request.getApplicationId();
@@ -142,6 +147,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             logger.info("GetActivationStatusRequest received, activation ID: {}", activationId);
@@ -161,6 +170,11 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public InitActivationResponse initActivation(InitActivationRequest request) throws GenericServiceException {
+        if (request.getUserId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        // The maxFailedCount and activationExpireTimestamp values can be null, in this case default values are used
         try {
             String userId = request.getUserId();
             Long applicationId = request.getApplicationId();
@@ -182,6 +196,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public PrepareActivationResponse prepareActivation(PrepareActivationRequest request) throws GenericServiceException {
+        if (request.getActivationCode() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getMac() == null || request.getEncryptedData() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationCode = request.getActivationCode();
             String applicationKey = request.getApplicationKey();
@@ -205,6 +223,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateActivationResponse createActivation(CreateActivationRequest request) throws GenericServiceException {
+        if (request.getUserId() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getMac() == null || request.getEncryptedData() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             // Get request parameters
             String userId = request.getUserId();
@@ -236,7 +258,6 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     }
 
     private VerifySignatureResponse verifySignatureImplNonTransaction(VerifySignatureRequest request, KeyValueMap additionalInfo) throws GenericServiceException {
-
         // Get request data
         String activationId = request.getActivationId();
         String applicationKey = request.getApplicationKey();
@@ -255,6 +276,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public VerifySignatureResponse verifySignature(VerifySignatureRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getData() == null || request.getSignature() == null || request.getSignatureType() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("VerifySignatureRequest received, activation ID: {}", request.getActivationId());
             VerifySignatureResponse response = this.verifySignatureImplNonTransaction(request, null);
@@ -272,6 +297,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getData() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             String data = request.getData();
@@ -291,6 +320,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws GenericServiceException {
+        if (request.getData() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             long applicationId = request.getApplicationId();
             String data = request.getData();
@@ -310,6 +343,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getData() == null || request.getSignature() == null || request.getSignatureType() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             final String activationId = request.getActivationId();
             final String data = request.getData();
@@ -331,6 +368,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CommitActivationResponse commitActivation(CommitActivationRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             logger.info("CommitActivationRequest received, activation ID: {}", activationId);
@@ -349,6 +390,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public RemoveActivationResponse removeActivation(RemoveActivationRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             logger.info("RemoveActivationRequest received, activation ID: {}", activationId);
@@ -367,6 +412,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public BlockActivationResponse blockActivation(BlockActivationRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             String reason = request.getReason();
@@ -386,6 +435,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public UnblockActivationResponse unblockActivation(UnblockActivationRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             logger.info("UnblockActivationRequest received, activation ID: {}", activationId);
@@ -405,6 +458,12 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public VaultUnlockResponse vaultUnlock(VaultUnlockRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getSignature() == null
+                || request.getSignatureType() == null || request.getSignedData() == null
+                || request.getEphemeralPublicKey() == null || request.getEncryptedData() == null || request.getMac() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             // Get request data
             final String activationId = request.getActivationId();
@@ -445,6 +504,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getData() == null || request.getSignature() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             String signedData = request.getData();
@@ -467,6 +530,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request) throws GenericServiceException {
+        if (request.getUserId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
 
             String userId = request.getUserId();
@@ -489,6 +556,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             String activationId = request.getActivationId();
             Date startingDate = XMLGregorianCalendarConverter.convertTo(request.getTimestampFrom());
@@ -537,6 +608,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request) throws GenericServiceException {
+        if (request.getApplicationKey() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("LookupApplicationByAppKeyRequest received");
             LookupApplicationByAppKeyResponse response = behavior.getApplicationServiceBehavior().lookupApplicationByAppKey(request.getApplicationKey());
@@ -554,6 +629,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateApplicationResponse createApplication(CreateApplicationRequest request) throws GenericServiceException {
+        if (request.getApplicationName() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CreateApplicationRequest received, application name: {}", request.getApplicationName());
             CreateApplicationResponse response = behavior.getApplicationServiceBehavior().createApplication(request.getApplicationName(), keyConversionUtilities);
@@ -571,6 +650,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request) throws GenericServiceException {
+        if (request.getApplicationVersionName() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CreateApplicationVersionRequest received, application ID: {}, application version name: {}", request.getApplicationId(), request.getApplicationVersionName());
             CreateApplicationVersionResponse response = behavior.getApplicationServiceBehavior().createApplicationVersion(request.getApplicationId(), request.getApplicationVersionName());
@@ -622,6 +705,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateIntegrationResponse createIntegration(CreateIntegrationRequest request) throws GenericServiceException {
+        if (request.getName() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CreateIntegrationRequest received, name: {}", request.getName());
             CreateIntegrationResponse response = behavior.getIntegrationBehavior().createIntegration(request);
@@ -664,6 +751,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request) throws GenericServiceException {
+        if (request.getName() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CreateCallbackUrlRequest received, name: {}", request.getName());
             CreateCallbackUrlResponse response = behavior.getCallbackUrlBehavior().createCallbackUrl(request);
@@ -709,6 +800,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CreateTokenResponse createToken(CreateTokenRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getEncryptedData() == null || request.getMac() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CreateTokenRequest received, activation ID: {}", request.getActivationId());
             CreateTokenResponse response = behavior.getTokenBehavior().createToken(request, keyConversionUtilities);
@@ -726,6 +821,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public ValidateTokenResponse validateToken(ValidateTokenRequest request) throws GenericServiceException {
+        if (request.getTokenId() == null || request.getNonce() == null || request.getTokenDigest() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("ValidateTokenRequest received, token ID: {}", request.getTokenId());
             ValidateTokenResponse response = behavior.getTokenBehavior().validateToken(request);
@@ -743,6 +842,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public RemoveTokenResponse removeToken(RemoveTokenRequest request) throws GenericServiceException {
+        if (request.getTokenId() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("RemoveTokenRequest received, token ID: {}", request.getTokenId());
             RemoveTokenResponse response = behavior.getTokenBehavior().removeToken(request);
@@ -757,6 +860,11 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws GenericServiceException {
+        if (request.getApplicationKey() == null || request.getEphemeralPublicKey() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        // The activationId value can be null in case the decryptor is used in application scope
         try {
             logger.info("GetEciesDecryptorRequest received, application key: {}, activation ID: {}", request.getApplicationKey(), request.getActivationId());
             GetEciesDecryptorResponse response = behavior.getEciesEncryptionBehavior().getEciesDecryptorParameters(request);
@@ -774,6 +882,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getEncryptedData() == null || request.getMac() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("StartUpgradeRequest received, application key: {}, activation ID: {}", request.getApplicationKey(), request.getActivationId());
             StartUpgradeResponse response = behavior.getUpgradeServiceBehavior().startUpgrade(request);
@@ -791,6 +903,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
     @Override
     @Transactional
     public CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request) throws GenericServiceException {
+        if (request.getActivationId() == null || request.getApplicationKey() == null) {
+            logger.warn("Invalid request");
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         try {
             logger.info("CommitUpgradeRequest received, application key: {}, activation ID: {}", request.getApplicationKey(), request.getActivationId());
             CommitUpgradeResponse response = behavior.getUpgradeServiceBehavior().commitUpgrade(request);

--- a/powerauth-java-server/src/main/resources/i18n/errors.properties
+++ b/powerauth-java-server/src/main/resources/i18n/errors.properties
@@ -38,3 +38,6 @@ ServiceError.ERR0018=Data decryption failed.
 ServiceError.ERR0019=Token was not successfully generated.
 ServiceError.ERR0020=Master DB encryption key is not configured.
 ServiceError.ERR0021=Unsupported encryption mode.
+ServiceError.ERR0022=Generic cryptography error occurred.
+ServiceError.ERR0023=Cryptography provider is initialized incorrectly.
+ServiceError.ERR0024=Invalid request received.


### PR DESCRIPTION
This PR introduces custom activation implementation on PowerAuth server.

I added the timestamp expiration check which was previously missing to v2 version, too.