### PR TITLE
Validate user ID when initializing activations

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -448,8 +448,8 @@ public class ActivationServiceBehavior {
             // Generate timestamp in advance
             Date timestamp = new Date();
 
-            if (userId == null) {
-                logger.warn("User ID not specified");
+            if (userId == null || userId.isEmpty() || userId.length() > 255) {
+                logger.warn("User ID not specified or invalid");
                 throw localizationProvider.buildExceptionForCode(ServiceError.NO_USER_ID);
             }
 


### PR DESCRIPTION
I added basic validations of user ID, automated tests found that activation can have empty user ID.