### PR TITLE
Fix #227: InitActivation should use version 2 duplicity check when checking for duplicates

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
@@ -104,14 +104,18 @@ public interface ActivationRepository extends CrudRepository<ActivationRecordEnt
     ActivationRecordEntity findCreatedActivationWithoutLock(Long applicationId, String activationCode, Collection<ActivationStatus> states, Date currentTimestamp);
 
     /**
-     * Get count of activations identified by an activation code associated with given application.
+     * Get count of activations identified by an activation short ID associated with given application.
+     *
+     * The check for the first half of activation code is required for version 2.0 of PowerAuth crypto. In future the
+     * uniqueness check will be extended to whole activation code once version 2.0 of PowerAuth crypto is no longer
+     * supported.
      *
      * @param applicationId     Application ID
-     * @param activationCode    Activation code
+     * @param activationIdShort Activation ID short
      * @return Count of activations matching the search criteria
      */
-    @Query("SELECT COUNT(a) FROM ActivationRecordEntity a WHERE a.application.id = ?1 AND a.activationCode = ?2")
-    Long getActivationCountByActivationCode(Long applicationId, String activationCode);
+    @Query("SELECT COUNT(a) FROM ActivationRecordEntity a WHERE a.application.id = ?1 AND a.activationCode LIKE ?2%")
+    Long getActivationCountByActivationIdShort(Long applicationId, String activationIdShort);
 
     /**
      * Find the first activation associated with given application by the activation ID short.

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
@@ -110,12 +110,32 @@ public interface ActivationRepository extends CrudRepository<ActivationRecordEnt
      * uniqueness check will be extended to whole activation code once version 2.0 of PowerAuth crypto is no longer
      * supported.
      *
+     * This method will be removed when crypto version 2.0 is deprecated.
+     *
      * @param applicationId     Application ID
      * @param activationIdShort Activation ID short
      * @return Count of activations matching the search criteria
      */
     @Query("SELECT COUNT(a) FROM ActivationRecordEntity a WHERE a.application.id = ?1 AND a.activationCode LIKE ?2%")
     Long getActivationCountByActivationIdShort(Long applicationId, String activationIdShort);
+
+    /**
+     * Get count of activations identified by an activation code associated with given application.
+     *
+     * The check for the first half of activation code is required for version 2.0 of PowerAuth crypto. In future the
+     * uniqueness check will be extended to whole activation code once version 2.0 of PowerAuth crypto is no longer
+     * supported.
+     *
+     * @param applicationId  Application ID
+     * @param activationCode Activation code
+     * @return Count of activations matching the search criteria
+     */
+    default Long getActivationCountByActivationCode(Long applicationId, String activationCode) {
+        if (activationCode == null || activationCode.length() != 23) {
+            throw new IllegalArgumentException("Invalid activation code: " + activationCode);
+        }
+        return getActivationCountByActivationIdShort(applicationId, activationCode.substring(0, 11));
+    }
 
     /**
      * Find the first activation associated with given application by the activation ID short.

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -509,7 +509,8 @@ public class ActivationServiceBehavior {
             String activationCode = null;
             for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationCodeIterations(); i++) {
                 String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
-                Long activationCount = activationRepository.getActivationCountByActivationCode(applicationId, tmpActivationCode);
+                String tmpActivationShortId = tmpActivationCode.substring(0, 11);
+                Long activationCount = activationRepository.getActivationCountByActivationIdShort(applicationId, tmpActivationShortId);
                 // Check that the temporary activation code is unique, otherwise generate a different code
                 if (activationCount == 0) {
                     activationCode = tmpActivationCode;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -511,7 +511,7 @@ public class ActivationServiceBehavior {
                 String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
                 String tmpActivationShortId = tmpActivationCode.substring(0, 11);
                 Long activationCount = activationRepository.getActivationCountByActivationIdShort(applicationId, tmpActivationShortId);
-                // Check that the temporary activation code is unique, otherwise generate a different code
+                // Check that the temporary short activation ID is unique, otherwise generate a different activation code
                 if (activationCount == 0) {
                     activationCode = tmpActivationCode;
                     break;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -509,8 +509,7 @@ public class ActivationServiceBehavior {
             String activationCode = null;
             for (int i = 0; i < powerAuthServiceConfiguration.getActivationGenerateActivationCodeIterations(); i++) {
                 String tmpActivationCode = powerAuthServerActivation.generateActivationCode();
-                String tmpActivationShortId = tmpActivationCode.substring(0, 11);
-                Long activationCount = activationRepository.getActivationCountByActivationIdShort(applicationId, tmpActivationShortId);
+                Long activationCount = activationRepository.getActivationCountByActivationCode(applicationId, tmpActivationCode);
                 // Check that the temporary short activation ID is unique, otherwise generate a different activation code
                 if (activationCount == 0) {
                     activationCode = tmpActivationCode;


### PR DESCRIPTION
The uniqueness check is reverted to version 2 of crypto (the condition is unique `activationIdShort` per application instead of unique `activationCode` per application). 