### PR TITLE
 Fix #249: Backport fix of WSDL for vault unlock error state in Axis client

### DIFF
--- a/powerauth-java-client-axis/pom.xml
+++ b/powerauth-java-client-axis/pom.xml
@@ -21,7 +21,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>powerauth-java-client-axis</artifactId>
-	<version>0.19.0</version>
+	<version>0.19.1</version>
 	<name>powerauth-java-client-axis</name>
 	<description>PowerAuth Server SOAP Service Client - Axis</description>
 

--- a/powerauth-java-client-axis/src/main/resources/soap/wsdl/service.wsdl
+++ b/powerauth-java-client-axis/src/main/resources/soap/wsdl/service.wsdl
@@ -713,7 +713,7 @@
                         <xs:element maxOccurs="1" minOccurs="0" name="blockedReason" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="remainingAttempts" type="xs:integer"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signatureValid" type="xs:boolean"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="encryptedVaultEncryptionKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="encryptedVaultEncryptionKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/powerauth-java-client-spring/src/main/resources/soap/wsdl/service.wsdl
+++ b/powerauth-java-client-spring/src/main/resources/soap/wsdl/service.wsdl
@@ -713,7 +713,7 @@
                         <xs:element maxOccurs="1" minOccurs="0" name="blockedReason" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="remainingAttempts" type="xs:integer"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="signatureValid" type="xs:boolean"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="encryptedVaultEncryptionKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="encryptedVaultEncryptionKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-2.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-2.0.xsd
@@ -715,7 +715,7 @@
                 <xs:element name="blockedReason" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="remainingAttempts" type="xs:integer"  minOccurs="1" maxOccurs="1"/>
                 <xs:element name="signatureValid" type="xs:boolean"  minOccurs="1" maxOccurs="1"/>
-                <xs:element name="encryptedVaultEncryptionKey" type="xs:string"  minOccurs="1" maxOccurs="1"/>
+                <xs:element name="encryptedVaultEncryptionKey" type="xs:string"  minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
This pull request backports the fix of WSDL from issue https://github.com/wultra/powerauth-server/issues/228 for vault unlock due to Axis client error when vault unlock fails.

The version of `powerauth-java-client-axis` project is increased to `0.19.1`. I fixed the WSDL and XSD in all projects, however I didn't increase other project versions because we only need to release the Axis client.