### PR TITLE
Fix #254: Remove workaround for follow-on-locking in Hibernate

### DIFF
--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -58,10 +58,6 @@ powerauth.service.crypto.signatureValidationLookahead=20
 # Database Lock Timeout Configuration
 spring.jpa.properties.lock.timeout=10000
 
-# TODO: Workaround for Hibernate <5.2 and Oracle harmless warnings
-# Disabled follow-on-locking warnings
-logging.level.org.hibernate.loader.Loader=ERROR
-
 # Disable JMX
 spring.jmx.enabled=false
 


### PR DESCRIPTION
The workaround is no longer required.