### PR TITLE
Fix #278: Use case sensitive index definition for MySQL

### DIFF
--- a/docs/PowerAuth-Server-0.21.0.md
+++ b/docs/PowerAuth-Server-0.21.0.md
@@ -58,42 +58,42 @@ Migration script for MySQL:
 --
 --  Added Column ACTIVATION_CODE in Table PA_ACTIVATION
 --
-ALTER TABLE PA_ACTIVATION ADD ACTIVATION_CODE VARCHAR(255);
+ALTER TABLE `pa_activation` ADD `activation_code` VARCHAR(255);
 
 --
 --  Added Column CTR_DATA in Table PA_ACTIVATION
 --
-ALTER TABLE PA_ACTIVATION ADD CTR_DATA VARCHAR(255);
+ALTER TABLE `pa_activation` ADD `ctr_data` VARCHAR(255);
 
 --
 --  Added Column VERSION in Table PA_ACTIVATION
 --
-ALTER TABLE PA_ACTIVATION ADD VERSION INT(2) DEFAULT 2;
+ALTER TABLE `pa_activation` ADD `version` INT(2) DEFAULT 2;
 
 --
 --  Added Column ACTIVATION_CTR_DATA in Table PA_SIGNATURE_AUDIT
 --
-ALTER TABLE PA_SIGNATURE_AUDIT ADD ACTIVATION_CTR_DATA VARCHAR(255);
+ALTER TABLE `pa_signature_audit` ADD `activation_ctr_data` VARCHAR(255);
 
 --
 --  Added Column VERSION in Table PA_SIGNATURE_AUDIT
 --
-ALTER TABLE PA_SIGNATURE_AUDIT ADD VERSION INT(2) DEFAULT 2;
+ALTER TABLE `pa_signature_audit` ADD `version` INT(2) DEFAULT 2;
 
 --
 --  Column ACTIVATION_CODE Filled with Data from ACTIVATION_ID_SHORT || '-' || ACTIATION_OTP
 --
-UPDATE PA_ACTIVATION SET ACTIVATION_CODE = ACTIVATION_ID_SHORT || '-' || ACTIVATION_OTP;
+UPDATE `pa_activation` SET `activation_code` = `activation_id_short` || '-' || `activation_otp`;
 
 --
 --  Dropped Column ACTIVATION_ID_SHORT in Table PA_ACTIVATION
 --
-ALTER TABLE PA_ACTIVATION DROP COLUMN ACTIVATION_ID_SHORT;
+ALTER TABLE `pa_activation` DROP COLUMN `activation_id_short`;
 
 --
 --  Dropped Column ACTIVATION_OTP in Table PA_ACTIVATION
 --
-ALTER TABLE PA_ACTIVATION DROP COLUMN ACTIVATION_OTP;
+ALTER TABLE `pa_activation` DROP COLUMN `activation_otp`;
 ```
 
 ## Database Indexes

--- a/docs/PowerAuth-Server-0.21.0.md
+++ b/docs/PowerAuth-Server-0.21.0.md
@@ -133,19 +133,19 @@ CREATE INDEX PA_TOKEN_ACTIVATION ON PA_TOKEN(ACTIVATION_ID);
 
 Script for MySQL (foreign key indexes are created automatically in InnoDB):
 ```sql
-CREATE INDEX PA_ACTIVATION_CODE ON PA_ACTIVATION(ACTIVATION_CODE);
+CREATE INDEX `pa_activation_code` on `pa_activation`(`activation_code`);
 
-CREATE INDEX PA_ACTIVATION_USER_ID ON PA_ACTIVATION(USER_ID);
+CREATE INDEX `pa_activation_user_id` on `pa_activation`(`user_id`);
 
-CREATE INDEX PA_ACTIVATION_HISTORY_CREATED ON PA_ACTIVATION_HISTORY(TIMESTAMP_CREATED);
+CREATE INDEX `pa_activation_history_created` on `pa_activation_history`(`timestamp_created`);
 
-CREATE UNIQUE INDEX PA_APP_VERSION_APP_KEY ON PA_APPLICATION_VERSION(APPLICATION_KEY);
+CREATE UNIQUE INDEX `pa_app_version_app_key` on `pa_application_version`(`application_key`);
 
-CREATE INDEX PA_APP_CALLBACK_APP ON PA_APPLICATION_CALLBACK(APPLICATION_ID);
+CREATE INDEX `pa_app_callback_app` ON `pa_application_callback`(`application_id`);
 
-CREATE UNIQUE INDEX PA_INTEGRATION_TOKEN ON PA_INTEGRATION(CLIENT_TOKEN);
+CREATE UNIQUE INDEX `pa_integration_token` on `pa_integration`(`client_token`);
 
-CREATE INDEX PA_SIGNATURE_AUDIT_CREATED ON PA_SIGNATURE_AUDIT(TIMESTAMP_CREATED);
+CREATE INDEX `pa_signature_audit_created` on `pa_signature_audit`(`timestamp_created`);
 ```
 
 ## PowerAuth Protocol Version 3.0

--- a/docs/PowerAuth-Server-0.21.0.md
+++ b/docs/PowerAuth-Server-0.21.0.md
@@ -133,19 +133,19 @@ CREATE INDEX PA_TOKEN_ACTIVATION ON PA_TOKEN(ACTIVATION_ID);
 
 Script for MySQL (foreign key indexes are created automatically in InnoDB):
 ```sql
-CREATE INDEX `pa_activation_code` on `pa_activation`(`activation_code`);
+CREATE INDEX `pa_activation_code` ON `pa_activation`(`activation_code`);
 
-CREATE INDEX `pa_activation_user_id` on `pa_activation`(`user_id`);
+CREATE INDEX `pa_activation_user_id` ON `pa_activation`(`user_id`);
 
-CREATE INDEX `pa_activation_history_created` on `pa_activation_history`(`timestamp_created`);
+CREATE INDEX `pa_activation_history_created` ON `pa_activation_history`(`timestamp_created`);
 
-CREATE UNIQUE INDEX `pa_app_version_app_key` on `pa_application_version`(`application_key`);
+CREATE UNIQUE INDEX `pa_app_version_app_key` ON `pa_application_version`(`application_key`);
 
 CREATE INDEX `pa_app_callback_app` ON `pa_application_callback`(`application_id`);
 
-CREATE UNIQUE INDEX `pa_integration_token` on `pa_integration`(`client_token`);
+CREATE UNIQUE INDEX `pa_integration_token` ON `pa_integration`(`client_token`);
 
-CREATE INDEX `pa_signature_audit_created` on `pa_signature_audit`(`timestamp_created`);
+CREATE INDEX `pa_signature_audit_created` ON `pa_signature_audit`(`timestamp_created`);
 ```
 
 ## PowerAuth Protocol Version 3.0

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -144,17 +144,17 @@ CREATE TABLE `pa_activation_history` (
 -- Indexes for better performance. InnoDB engine creates indexes on foreign keys automatically, so they are not included.
 --
 
-CREATE INDEX `pa_activation_code` on `pa_activation`(`activation_code`);
+CREATE INDEX `pa_activation_code` ON `pa_activation`(`activation_code`);
 
-CREATE INDEX `pa_activation_user_id` on `pa_activation`(`user_id`);
+CREATE INDEX `pa_activation_user_id` ON `pa_activation`(`user_id`);
 
-CREATE INDEX `pa_activation_history_created` on `pa_activation_history`(`timestamp_created`);
+CREATE INDEX `pa_activation_history_created` ON `pa_activation_history`(`timestamp_created`);
 
-CREATE UNIQUE INDEX `pa_app_version_app_key` on `pa_application_version`(`application_key`);
+CREATE UNIQUE INDEX `pa_app_version_app_key` ON `pa_application_version`(`application_key`);
 
 CREATE INDEX `pa_app_callback_app` ON `pa_application_callback`(`application_id`);
 
-CREATE UNIQUE INDEX `pa_integration_token` on `pa_integration`(`client_token`);
+CREATE UNIQUE INDEX `pa_integration_token` ON `pa_integration`(`client_token`);
 
-CREATE INDEX `pa_signature_audit_created` on `pa_signature_audit`(`timestamp_created`);
+CREATE INDEX `pa_signature_audit_created` ON `pa_signature_audit`(`timestamp_created`);
 

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -140,20 +140,21 @@ CREATE TABLE `pa_activation_history` (
   CONSTRAINT `FK_HISTORY_ACTIVATION_ID` FOREIGN KEY (`activation_id`) REFERENCES `pa_activation` (`activation_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
----
---- Indexes for better performance. InnoDB engine creates indexes on foreign keys automatically, so they are not included.
----
+--
+-- Indexes for better performance. InnoDB engine creates indexes on foreign keys automatically, so they are not included.
+--
 
-CREATE INDEX PA_ACTIVATION_CODE ON PA_ACTIVATION(ACTIVATION_CODE);
+CREATE INDEX `pa_activation_code` on `pa_activation`(`activation_code`);
 
-CREATE INDEX PA_ACTIVATION_USER_ID ON PA_ACTIVATION(USER_ID);
+CREATE INDEX `pa_activation_user_id` on `pa_activation`(`user_id`);
 
-CREATE INDEX PA_ACTIVATION_HISTORY_CREATED ON PA_ACTIVATION_HISTORY(TIMESTAMP_CREATED);
+CREATE INDEX `pa_activation_history_created` on `pa_activation_history`(`timestamp_created`);
 
-CREATE UNIQUE INDEX PA_APP_VERSION_APP_KEY ON PA_APPLICATION_VERSION(APPLICATION_KEY);
+CREATE UNIQUE INDEX `pa_app_version_app_key` on `pa_application_version`(`application_key`);
 
-CREATE INDEX PA_APP_CALLBACK_APP ON PA_APPLICATION_CALLBACK(APPLICATION_ID);
+CREATE INDEX `pa_app_callback_app` ON `pa_application_callback`(`application_id`);
 
-CREATE UNIQUE INDEX PA_INTEGRATION_TOKEN ON PA_INTEGRATION(CLIENT_TOKEN);
+CREATE UNIQUE INDEX `pa_integration_token` on `pa_integration`(`client_token`);
 
-CREATE INDEX PA_SIGNATURE_AUDIT_CREATED ON PA_SIGNATURE_AUDIT(TIMESTAMP_CREATED);
+CREATE INDEX `pa_signature_audit_created` on `pa_signature_audit`(`timestamp_created`);
+


### PR DESCRIPTION
The original index definition failed in Docker while it worked fine on my newer version of MySQL.