### PR TITLE
Fix #292: Add jboss-deployment-structure.xml file

### DIFF
--- a/docs/Deploying-PowerAuth-Server.md
+++ b/docs/Deploying-PowerAuth-Server.md
@@ -176,6 +176,10 @@ $ curl -s -H "Content-Type: application/json" -X POST -d '{ "requestObject": { "
 }
 ```
 
+## Deploying PowerAuth Server On JBoss / Wildfly
+
+Follow the extra instructions in chapter [Deploying PowerAuth Server on JBoss / Wildfly](./Deploying-Wildfly.md).
+
 ## Troubleshooting
 
 ### Issues With Database Connectivity

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -1,0 +1,100 @@
+# Deploying PowerAuth Server on JBoss / Wildfly
+
+## JBoss Deployment Descriptor 
+
+PowerAuth server contains the following configuration in `jboss-deployment-structure.xml` file for JBoss:
+
+```
+<?xml version="1.0"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+	<deployment>
+		<exclude-subsystems>
+			<!-- disable the logging subsystem because the application manages its own logging independently -->
+			<subsystem name="logging" />
+		</exclude-subsystems>
+
+		<dependencies>
+			<module name="com.wultra.powerauth.server.conf" />
+		</dependencies>
+		<local-last value="true" />
+	</deployment>
+</jboss-deployment-structure>
+```
+
+The deployment descriptor requires configuration of the `com.wultra.powerauth.server.conf` module.
+
+## JBoss Module for PowerAuth Server Configuration
+
+Create a new module in `PATH_TO_JBOSS/modules/system/layers/base/com/wultra/powerauth/server/conf/main`.
+
+The files described below should be added into this folder.
+
+### Main Module Configuration
+
+The `module.xml` configuration is used for module registration. It also adds resources from the module folder to classpath:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.wultra.powerauth.server.conf">
+    <resources>
+        <resource-root path="." />
+    </resources>
+</module>
+```
+
+### Logging Configuration
+
+Use the `logback.xml` file to configure logging, for example:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+        <property name="LOG_FILE_DIR" value="/var/log/powerauth" />
+        <property name="LOG_FILE_NAME" value="powerauth-server" />
+        <property name="INSTANCE_ID" value="${jboss.server.name}" />
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${LOG_FILE_DIR}/${LOG_FILE_NAME}-${INSTANCE_ID}.log</file>
+                <immediateFlush>true</immediateFlush>
+                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                        <fileNamePattern>${LOG_FILE_DIR}/${LOG_FILE_NAME}-${INSTANCE_ID}-%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+                        <maxFileSize>10MB</maxFileSize>
+                        <maxHistory>5</maxHistory>
+                        <totalSizeCap>100MB</totalSizeCap>
+                </rollingPolicy>
+                <encoder>
+                        <charset>UTF-8</charset>
+                        <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+        </appender>
+
+        <logger name="com.wultra" level="INFO" />
+        <logger name="io.getlime" level="INFO" />
+
+        <root level="INFO">
+                <appender-ref ref="FILE" />
+        </root>
+</configuration>
+```
+
+### Application Configuration
+
+The `application-ext.properties` file is used to override default configuration properties, for example:
+```
+# Database Configuration - Oracle
+spring.datasource.url=jdbc:oracle:thin:@//[host]:[port]/[servicename]
+spring.datasource.username=powerauth
+spring.datasource.password=powerauth
+spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
+
+# Application Service Configuration
+powerauth.service.applicationEnvironment=TEST
+```
+
+PowerAuth Server Spring application uses the `ext` Spring profile which activates overriding of default properties by `application-ext.properties`. 
+
+### Bouncy Castle Installation
+
+The Bouncy Castle module for JBoss / Wildfly needs to be enabled as a global module for PowerAuth.
+
+Follow the instructions in the [Installing Bouncy Castle](./Installing-Bouncy-Castle.md) chapter. 
+Note that the instructions differ based on Java version and application server.

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -97,4 +97,4 @@ PowerAuth Server Spring application uses the `ext` Spring profile which activate
 The Bouncy Castle module for JBoss / Wildfly needs to be enabled as a global module for PowerAuth.
 
 Follow the instructions in the [Installing Bouncy Castle](./Installing-Bouncy-Castle.md) chapter. 
-Note that the instructions differ based on Java version and application server.
+Note that the instructions differ based on Java version and application server type.

--- a/docs/Installing-Bouncy-Castle.md
+++ b/docs/Installing-Bouncy-Castle.md
@@ -53,9 +53,9 @@ https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
 _Warning: Bouncy Castle library will not work properly in case any war file deployed to Tomcat contains another copy of the Bouncy Castle library, even if the war file is not related to PowerAuth.
 Bouncy Castle library must be only present in the `${CATALINA_HOME}/lib` folder. The `key spec not recognized` error message will appear in Tomcat log in this case._
 
-### Bouncy Castle on Wildfly
+### Bouncy Castle on JBoss / Wildfly
 
-In order to make PowerAuth Server work on Wildfly, you need to enable the Bouncy Castle module on the server, by adding the `<global-modules>` element in the `standalone.xml` file:
+In order to make PowerAuth Server work on JBoss / Wildfly, you need to enable the Bouncy Castle module on the server, by adding the `<global-modules>` element in the `standalone.xml` file:
 
 ```xml
 <subsystem xmlns="urn:jboss:domain:ee:4.0">
@@ -87,7 +87,7 @@ In case of any error or different output, please check the troubleshooting guide
 
 Bouncy Castle library is installed in two steps on Java 8:
 - Bouncy Castle security provider needs to be configured in `java.security` configuration file.
-- Java 8 provides a library extension mechanism which can be used to installed Bouncy Castle with exception of Wildfly which has it's own mechanism for installing Bouncy Castle.  
+- Java 8 provides a library extension mechanism which can be used to installed Bouncy Castle with exception of JBoss / Wildfly which has it's own mechanism for installing Bouncy Castle.  
 
 ### Configuring Java Security
 
@@ -125,9 +125,9 @@ Copy [`bcprov-jdk15on-[VERSION].jar`](https://mvnrepository.com/artifact/org.bou
 You can get the Bouncy Castle provider here:
 https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
 
-### Bouncy Castle on Wildfly
+### Bouncy Castle on JBoss / Wildfly
 
-In order to make PowerAuth Server work on Wildfly, you need to enable the Bouncy Castle module on the server, by adding the `<global-modules>` element in the `standalone.xml` file:
+In order to make PowerAuth Server work on JBoss / Wildfly, you need to enable the Bouncy Castle module on the server, by adding the `<global-modules>` element in the `standalone.xml` file:
 
 ```xml
 <subsystem xmlns="urn:jboss:domain:ee:4.0">
@@ -138,7 +138,7 @@ In order to make PowerAuth Server work on Wildfly, you need to enable the Bouncy
 </subsystem>
 ```
 
-Note that when Wildfly's Bouncy Castle module is used, Bouncy Castle should not be present in the `lib/ext` folder of the Java runtime, otherwise the following error can occur: `key spec not recognized` due to clash of Bouncy Castle libraries.
+Note that when Bouncy Castle module for JBoss / Wildfly is used, Bouncy Castle should not be present in the `lib/ext` folder of the Java runtime, otherwise the following error can occur: `key spec not recognized` due to clash of Bouncy Castle libraries.
 
 ### Testing the Installation
 
@@ -176,7 +176,7 @@ In case you get the following error: `key spec not recognized`, there are possib
 
 - Tomcat on Java 11: Check that Bouncy Castle library is installed in `${CATALINA_HOME}/lib`.
 - Tomcat on Java 8: Check that Bouncy Castle library is installed in `${JDK_HOME}/jre/lib/ext` and it is not present in `${CATALINA_HOME}/lib`.
-- Wildfly on Java 11: Check that Bouncy Castle library is installed as a module in Wildfly.
-- Wildfly on Java 8: Check that Bouncy Castle library is not installed in `${JDK_HOME}/jre/lib/ext` and it is installed as a module in Wildfly.
+- JBoss / Wildfly on Java 11: Check that Bouncy Castle library is installed as a module in JBoss / Wildfly.
+- JBoss / Wildfly on Java 8: Check that Bouncy Castle library is not installed in `${JDK_HOME}/jre/lib/ext` and it is installed as a module in JBoss / Wildfly.
 - All containers on Java 8/11: Check that none of the deployed war files contains Bouncy Castle library, even if the war file is not related to PowerAuth.
 Another copy of Bouncy Castle library would clash with the globally installed version of the library. This rule applies only for PowerAuth `2019.04` or later.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,6 +1,7 @@
 **Deployment Tutorials**
 
 - [Deploy PowerAuth Server](./Deploying-PowerAuth-Server.md)
+- [Deploy PowerAuth Server on JBoss / Wildfly](./Deploying-Wildfly.md)
 - [System Requirements](./System-Requirements.md)
 - [Migration Instructions](./Migration-Instructions.md)
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -19,6 +19,7 @@
 package io.getlime.security.powerauth.app.server.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Petr Dvorak, petr@wultra.com
  */
 @Configuration
+@ConfigurationProperties("ext")
 public class PowerAuthServiceConfiguration {
 
     /**

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Allow externalization of properties using application-ext.properties
+spring.profiles.active=ext
+
 # Database Keep-Alive
 spring.datasource.test-while-idle=true
 spring.datasource.test-on-borrow=true

--- a/powerauth-java-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/powerauth-java-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+	<deployment>
+		<exclude-subsystems>
+			<!-- disable the logging subsystem because the application manages its own logging independently -->
+			<subsystem name="logging" />
+		</exclude-subsystems>
+
+		<dependencies>
+			<module name="com.wultra.powerauth.server.conf" />
+		</dependencies>
+		<local-last value="true" />
+	</deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
This pull request adds the deployment descriptor for JBoss / Wildfly and activates the "ext" profile to allow overriding of `application properties`. It also includes documentation for deploying on JBoss / Wildfly.