### PR TITLE
Document SOAP interface for recovery codes

### DIFF
--- a/docs/SOAP-Service-Methods.md
+++ b/docs/SOAP-Service-Methods.md
@@ -61,7 +61,14 @@ The following `v3` methods are published using the service:
 - Activation Versioning
     - [startUpgrade](#method-startupgrade)
     - [commitUpgrade](#method-commitupgrade)
-
+- Activation Recovery
+    - [createRecoveryCode](#method-createrecoverycode)
+    - [confirmRecoveryCode](#method-confirmrecoverycode)
+    - [lookupRecoveryCodes](#method-lookuprecoverycodes)
+    - [revokeRecoveryCodes](#method-revokerecoverycodes)
+    - [recoveryCodeActivation](#method-recoverycodeactivation)
+    - [getRecoveryConfig](#method-getrecoveryconfig)
+    - [updateRecoveryConfig](#method-updaterecoveryconfig)
 The following `v2` methods are published using the service:
 - Activation Management
     - [prepareActivation (v2)](#method-prepareactivation-v2)
@@ -343,8 +350,8 @@ Assure a key exchange between PowerAuth Client and PowerAuth Server and prepare 
 | `String` | `activationCode` | Activation code which uses 4x5 characters in Base32 encoding separated by a "-" character |
 | `String` | `applicationKey` | A key (identifier) of an application, associated with given application version |
 | `String` | `ephemeralPublicKey` | A base64 encoded ephemeral public key for ECIES |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` | Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` | Base64 encoded mac of key and data for ECIES |
 
 ECIES request should contain following data (as JSON):
  - `activationName` - Visual representation of the device, for example "Johnny's iPhone" or "Samsung Galaxy S".
@@ -359,8 +366,8 @@ ECIES request should contain following data (as JSON):
 |------|------|-------------|
 | `String` | `activationId` | An UUID4 identifier of an activation |
 | `String` | `userId` | User ID |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 ECIES response contains following data (as JSON):
  - `activationId` - Represents a long `ACTIVATION_ID` that uniquely identifies given activation records.
@@ -382,8 +389,8 @@ Create an activation for given user and application, with provided maximum numbe
 | `Long` | `maxFailureCount` | How many failures are allowed for this activation |
 | `String` | `applicationKey` | A key (identifier) of an application, associated with given application version |
 | `String` | `ephemeralPublicKey` | A base64 encoded ephemeral public key for ECIES |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 ECIES request should contain following data (as JSON):
  - `activationName` - Visual representation of the device, for example "Johnny's iPhone" or "Samsung Galaxy S".
@@ -397,8 +404,8 @@ ECIES request should contain following data (as JSON):
 | Type | Name | Description |
 |------|------|-------------|
 | `String` | `activationId` | An UUID4 identifier of an activation |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 ECIES response contains following data (as JSON):
  - `activationId` - Represents a long `ACTIVATION_ID` that uniquely identifies given activation records.
@@ -715,8 +722,8 @@ Create a new token for the simple token-based authentication.
 | `String` | `activationId` | An identifier of an activation. |
 | `String` | `applicationKey` | A key (identifier) of an application, associated with given application version |
 | `String` | `ephemeralPublicKey` | A base64 encoded ephemeral public key for ECIES |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 | `SignatureType` | `signatureType` | Type of the signature (factors) used for token creation. |
 
 ECIES request should contain following data (an empty JSON object):
@@ -730,8 +737,8 @@ ECIES request should contain following data (an empty JSON object):
 
 | Type | Name | Description |
 |------|------|-------------|
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 ECIES response contains following data (example):
 ```json
@@ -808,8 +815,8 @@ Get the encrypted vault unlock key upon successful authentication using PowerAut
 | `String` | `signature` | PowerAuth signature |
 | `SignatureType` | `signatureType` | PowerAuth signature type |
 | `String` | `ephemeralPublicKey` | A base64 encoded ephemeral public key for ECIES |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 ECIES request should contain following data:
 ```json
@@ -832,8 +839,8 @@ You can provide following reasons for a vault unlocking:
 
 | Type | Name | Description |
 |------|------|-------------|
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 | `Boolean` | `signatureValid` | Indicates if the signature was correctly validated or if it was invalid (incorrect) |
 
 ECIES response contains following data (example):
@@ -880,7 +887,7 @@ Get the signature audit log for given user, application and date range. In case 
 | `Long` | `applicationId` | An identifier of an application |
 | `String` | `activationId` | An identifier of an activation |
 | `Long` | `activationCounter` | A counter value at the moment of a signature verification |
-| `String` | `activationCtrData` | Base 64 encoded hash based counter data |
+| `String` | `activationCtrData` | Base64 encoded hash based counter data |
 | `ActivationStatus` | `activationStatus` | An activation status at the moment of a signature verification |
 | `KeyValueMap` | `additionalInfo` | Key-value map with additional information |
 | `String` | `dataBase64` | A base64 encoded data sent with the signature |
@@ -923,6 +930,8 @@ Get the status change log for given activation and date range.
 | `Long` | `id` | Change ID |
 | `String` | `activationId` | An identifier of an activation |
 | `ActivationStatus` | `activationStatus` | An activation status at the moment of a signature verification |
+| `String` | `blockedReason` | Reason why activation was blocked (default: NOT_SPECIFIED) |
+| `String` | `externalUserId` | User ID of user who modified the activation. Null value is used if activation owner caused the change. |
 | `DateTime` | `timestampCreated` | Timestamp when the record was created |
 
 ## Integration management
@@ -1097,7 +1106,7 @@ Get ECIES decryptor data for request/response decryption on intermediate server.
 
 | Type | Name | Description |
 |------|------|-------------|
-| `String` | `secretKey` | Base 64 encoded secret key for ECIES |
+| `String` | `secretKey` | Base64 encoded secret key for ECIES |
 | `String` | `sharedInfo2` | The sharedInfo2 parameter for ECIES |
 
 ## Activation versioning
@@ -1115,8 +1124,8 @@ Upgrade activation to the most recent version supported by the server.
 | `String` | `activationId` | An UUID4 identifier of an activation (used only in activation scope, use null value in application scope) |
 | `String` | `applicationKey` | A key (identifier) of an application, associated with given application version |
 | `String` | `ephemeralPublicKey` | A base64 encoded ephemeral public key for ECIES |
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 #### Response
 
@@ -1124,10 +1133,12 @@ Upgrade activation to the most recent version supported by the server.
 
 | Type | Name | Description |
 |------|------|-------------|
-| `String` | `encryptedData` | Base 64 encoded encrypted data for ECIES |
-| `String` | `mac` |  Base 64 encoded mac of key and data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` |  Base64 encoded mac of key and data for ECIES |
 
 ### Method 'commitUpgrade'
+
+Commint activation upgrade.
 
 #### Request
 
@@ -1146,6 +1157,204 @@ Upgrade activation to the most recent version supported by the server.
 |------|------|-------------|
 | `Boolean` | `committed` | Flag specifying if activation upgrade was committed |
 
+## Activation recovery
+
+### Method 'createRecoveryCode'
+
+Create a recovery code for user.
+
+#### Request
+
+`CreateRecoveryCodeRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `applicationId` | An identifier of an application |
+| `String` | `userId` | An identifier of a user |
+| `Long` | `pukCount` | Number of PUKs to generate |
+| `Boolean` | `allowDuplicateCode` | Whether to allow duplicate recovery code for a user |
+
+#### Response
+
+`CreateRecoveryCodeResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `nonce` | A base64 encoded nonce used when generating recovery code |
+| `String` | `userId` | An identifier of a user |
+| `Long` | `recoveryCodeId` | Recovery code entity identifier |
+| `String` | `recoveryCodeMasked` | Recovery code with partial masking to avoid leaking recovery code |
+| `RecoveryCodeStatus` | `status` | Recovery code status |
+| `Puk[]` | `puks` | Recovery code PUKs |
+
+`CreateRecoveryCodeResponse.Puk`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long` | `pukIndex` | Index of the PUK, counting starts by 1 |
+| `Long` | `pukDerivationIndex` | Derivation index used when generating PUK |
+| `RecoveryPukStatus` | `status` | Recovery PUK status |
+
+### Method `confirmRecoveryCode`
+
+Confirm a recovery code recieved using recovery postcard.
+
+#### Request
+
+`ConfirmRecoveryCodeRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `activationId` | An UUID4 identifier of an activation |
+| `String` | `applicationKey` | A key (identifier) of an application, associated with given application version |
+| `String` | `ephemeralPublicKey` | Base64 encoded ephemeral public key for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` | Base64 encoded mac of key and data for ECIES |
+
+#### Response
+
+`ConfirmRecoveryCodeResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `activationId` | An UUID4 identifier of an activation |
+| `String` | `userId` | An identifier of a user |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` | Base64 encoded mac of key and data for ECIES |
+
+### Method `lookupRecoveryCodes`
+
+Lookup recovery codes.
+
+#### Request
+
+`LookupRecoveryCodesRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `userId` | An identifier of a user |
+| `String` | `activationId` | An UUID4 identifier of an activation |
+| `String` | `applicationId` | An identifier of an application |
+| `RecoveryCodeStatus` | `recoveryCodeStatus` | Recovery code status |
+| `RecoveryPukStatus` | `recoveryPukStatus` | Recovery PUK status | 
+
+#### Response
+
+`LookupRecoveryCodesResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long` | `recoveryCodeId` | Recovery code entity identifiers |
+| `String` | `recoveryCodeMasked` | Recovery code with partial masking to avoid leaking recovery code |
+| `String` | `userId` | An identifier of a user |
+| `Long` | `applicationId` | An identifier of an application |
+| `String` | `activationId` | An UUID4 identifier of an activation |
+| `RecoveryCodeStatus` | `status` | Recovery code status |
+| `Puk[]` | `puks` | Recovery code PUKs |
+
+`LookupRecoveryCodesResponse.Puk`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long` | `pukIndex` | Index of the PUK, counting starts by 1 |
+| `RecoveryPukStatus` | `status` | Recovery PUK status |
+
+### Method `revokeRecoveryCodes`
+
+Revoke recovery codes.
+
+#### Request
+
+`RevokeRecoveryCodesRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long[]` | `recoveryCodeIds` | Recovery code entity identifiers |
+
+#### Response
+
+`RevokeRecoveryCodesResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Boolean` | `revoked` | True if at least one recovery code was revoked |
+
+### Method `recoveryCodeActivation`
+
+Create an activation using recovery code.
+
+#### Request
+
+`RecoveryCodeActivationRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `recoveryCode` | Recovery code |
+| `String` | `puk` | Recovery PUK |
+| `String` | `applicationKey` | A key (identifier) of an application, associated with given application version |
+| `Long` | `maxFailureCount` | Maximum number of failures when using the recovery code |
+| `String` | `ephemeralPublicKey` | Base64 encoded encrypted data for ECIES |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` | Base64 encoded mac of key and data for ECIES |
+
+#### Response
+
+`RevokeRecoveryCodesResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `String` | `activationId` | An UUID4 identifier of an activation |
+| `String` | `userId` | An identifier of a user |
+| `String` | `encryptedData` | Base64 encoded encrypted data for ECIES |
+| `String` | `mac` | Base64 encoded mac of key and data for ECIES |
+
+### Method `getRecoveryConfig`
+
+Get configuration of activation recovery.
+
+#### Request
+
+`GetRecoveryConfigRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long` | `applicationId` | An identifier of an application |
+
+#### Response
+
+`GetRecoveryConfigResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long` | `applicationId` | An identifier of an application |
+| `Boolean` | `activationRecoveryEnabled` | Whether activation recovery is enabled |
+| `Boolean` | `recoveryPostcardEnabled` | Whether recovery postcard is enabled |
+| `String` | `postcardPublicKey` | Base64 encoded recovery postcard public key for PowerAuth server |
+| `String` | `remotePostcardPublicKey` | Base64 encoded recovery postcard public key for recovery postcard printing center |
+
+### Method `updateRecoveryConfig`
+
+Update configuration of activation recovery.
+
+#### Request
+
+`UpdateRecoveryConfigRequest`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Long` | `applicationId` | An identifier of an application |
+| `Boolean` | `activationRecoveryEnabled` | Whether activation recovery is enabled |
+| `Boolean` | `recoveryPostcardEnabled` | Whether recovery postcard is enabled |
+| `String` | `remotePostcardPublicKey` | Base64 encoded recovery postcard public key |
+
+#### Response
+
+`UpdateRecoveryConfigResponse`
+
+| Type | Name | Description |
+|------|------|-------------|
+| `Boolean` | `updated` | Whether recovery configuration was updated |   
+    
 ## Activation management (v2)
 
 ### Method 'prepareActivation' (v2)
@@ -1343,6 +1552,17 @@ This chapter lists all enums used by PowerAuth Server SOAP service.
     - POSSESSION_KNOWLEDGE
     - POSSESSION_BIOMETRY
     - POSSESSION_KNOWLEDGE_BIOMETRY
+    
+- `RecoveryCodeStatus` - Represent status of the recovery code, one of the following values:
+    - CREATED
+    - ACTIVE
+    - BLOCKED
+    - REVOKED
+    
+- `RecoveryPukStatus` - Represents status of the recovery PUK, one of the following values:
+    - VALID
+    - USED
+    - INVALID
 
 ## Used complex types
 

--- a/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
@@ -1305,7 +1305,7 @@ public class PowerAuthServiceClient {
         request.setApplicationId(applicationId);
         request.setActivationRecoveryEnabled(activationRecoveryEnabled);
         request.setRecoveryPostcardEnabled(recoveryPostcardEnabled);
-        request.setRemotePostcardPublicKeyBase64(remoteRecoveryPublicKeyBase64);
+        request.setRemotePostcardPublicKey(remoteRecoveryPublicKeyBase64);
         return updateRecoveryConfig(request);
     }
 

--- a/powerauth-java-client-axis/src/main/resources/soap/wsdl/service-v3.wsdl
+++ b/powerauth-java-client-axis/src/main/resources/soap/wsdl/service-v3.wsdl
@@ -1342,8 +1342,8 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
-                        <xs:element maxOccurs="1" minOccurs="0" name="postcardPublicKeyBase64" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKeyBase64" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="postcardPublicKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1357,7 +1357,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
-                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKeyBase64" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
@@ -1132,7 +1132,7 @@ public class PowerAuthServiceClient extends WebServiceGatewaySupport {
         request.setApplicationId(applicationId);
         request.setActivationRecoveryEnabled(activationRecoveryEnabled);
         request.setRecoveryPostcardEnabled(recoveryPostcardEnabled);
-        request.setRemotePostcardPublicKeyBase64(remoteRecoveryPublicKeyBase64);
+        request.setRemotePostcardPublicKey(remoteRecoveryPublicKeyBase64);
         return updateRecoveryConfig(request);
     }
 

--- a/powerauth-java-client-spring/src/main/resources/soap/wsdl/service-v3.wsdl
+++ b/powerauth-java-client-spring/src/main/resources/soap/wsdl/service-v3.wsdl
@@ -1342,8 +1342,8 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
-                        <xs:element maxOccurs="1" minOccurs="0" name="postcardPublicKeyBase64" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKeyBase64" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="postcardPublicKey" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1357,7 +1357,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
-                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKeyBase64" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/RecoveryServiceBehavior.java
@@ -569,8 +569,8 @@ public class RecoveryServiceBehavior {
         response.setApplicationId(applicationId);
         response.setActivationRecoveryEnabled(recoveryConfigEntity.getActivationRecoveryEnabled());
         response.setRecoveryPostcardEnabled(recoveryConfigEntity.getRecoveryPostcardEnabled());
-        response.setPostcardPublicKeyBase64(recoveryConfigEntity.getRecoveryPostcardPublicKeyBase64());
-        response.setRemotePostcardPublicKeyBase64(recoveryConfigEntity.getRemotePostcardPublicKeyBase64());
+        response.setPostcardPublicKey(recoveryConfigEntity.getRecoveryPostcardPublicKeyBase64());
+        response.setRemotePostcardPublicKey(recoveryConfigEntity.getRemotePostcardPublicKeyBase64());
         return response;
     }
 
@@ -613,9 +613,9 @@ public class RecoveryServiceBehavior {
             }
             recoveryConfigEntity.setActivationRecoveryEnabled(request.isActivationRecoveryEnabled());
             recoveryConfigEntity.setRecoveryPostcardEnabled(request.isRecoveryPostcardEnabled());
-            if (request.getRemotePostcardPublicKeyBase64() != null) {
-                recoveryConfigEntity.setRemotePostcardPublicKeyBase64(request.getRemotePostcardPublicKeyBase64());
-                if (request.getRemotePostcardPublicKeyBase64().isEmpty()) {
+            if (request.getRemotePostcardPublicKey() != null) {
+                recoveryConfigEntity.setRemotePostcardPublicKeyBase64(request.getRemotePostcardPublicKey());
+                if (request.getRemotePostcardPublicKey().isEmpty()) {
                     // Empty value is used to remove the remote postcard public key
                     recoveryConfigEntity.setRemotePostcardPublicKeyBase64(null);
                 }

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -1357,8 +1357,8 @@
                 <xs:element name="applicationId" type="xs:long" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="activationRecoveryEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="recoveryPostcardEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="postcardPublicKeyBase64" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="remotePostcardPublicKeyBase64" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="postcardPublicKey" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="remotePostcardPublicKey" type="xs:string" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -1372,7 +1372,7 @@
                 <xs:element name="applicationId" type="xs:long" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="activationRecoveryEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="recoveryPostcardEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="remotePostcardPublicKeyBase64" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="remotePostcardPublicKey" type="xs:string" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
This pull request contains following changes:
- Document SOAP interface for recovery codes
- Update SOAP interface method names to exclude base64 word
- Use `Base64` as one word instead of `Base 64`