### PR TITLE
Add configuration of allowMultipleRecoveryCodes to SOAP interface

### DIFF
--- a/docs/SOAP-Service-Methods.md
+++ b/docs/SOAP-Service-Methods.md
@@ -1328,6 +1328,7 @@ Get configuration of activation recovery.
 | `Long` | `applicationId` | An identifier of an application |
 | `Boolean` | `activationRecoveryEnabled` | Whether activation recovery is enabled |
 | `Boolean` | `recoveryPostcardEnabled` | Whether recovery postcard is enabled |
+| `Boolean` | `allowMultipleRecoveryCodes` | Whether multiple recovery codes per user are allowed |
 | `String` | `postcardPublicKey` | Base64 encoded recovery postcard public key for PowerAuth server |
 | `String` | `remotePostcardPublicKey` | Base64 encoded recovery postcard public key for recovery postcard printing center |
 
@@ -1344,6 +1345,7 @@ Update configuration of activation recovery.
 | `Long` | `applicationId` | An identifier of an application |
 | `Boolean` | `activationRecoveryEnabled` | Whether activation recovery is enabled |
 | `Boolean` | `recoveryPostcardEnabled` | Whether recovery postcard is enabled |
+| `Boolean` | `allowMultipleRecoveryCodes` | Whether multiple recovery codes per user are allowed |
 | `String` | `remotePostcardPublicKey` | Base64 encoded recovery postcard public key |
 
 #### Response

--- a/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
@@ -1294,15 +1294,17 @@ public class PowerAuthServiceClient {
      * @param applicationId Application ID.
      * @param activationRecoveryEnabled Whether activation recovery is enabled.
      * @param postcardRecoveryEnabled Whether recovery postcard is enabled.
+     * @param allowMultipleRecoveryCodes Whether multiple recovery codes are allowed.
      * @param remoteRecoveryPublicKeyBase64 Base64 encoded remote public key.
      * @return Revoke recovery code response.
      * @throws RemoteException In case of a business logic error.
      */
-    public PowerAuthPortV3ServiceStub.UpdateRecoveryConfigResponse updateRecoveryConfig(Long applicationId, Boolean activationRecoveryEnabled, Boolean recoveryPostcardEnabled, String remoteRecoveryPublicKeyBase64) throws RemoteException {
+    public PowerAuthPortV3ServiceStub.UpdateRecoveryConfigResponse updateRecoveryConfig(Long applicationId, Boolean activationRecoveryEnabled, Boolean recoveryPostcardEnabled, Boolean allowMultipleRecoveryCodes, String remoteRecoveryPublicKeyBase64) throws RemoteException {
         PowerAuthPortV3ServiceStub.UpdateRecoveryConfigRequest request = new PowerAuthPortV3ServiceStub.UpdateRecoveryConfigRequest();
         request.setApplicationId(applicationId);
         request.setActivationRecoveryEnabled(activationRecoveryEnabled);
         request.setRecoveryPostcardEnabled(recoveryPostcardEnabled);
+        request.setAllowMultipleRecoveryCodes(allowMultipleRecoveryCodes);
         request.setRemotePostcardPublicKey(remoteRecoveryPublicKeyBase64);
         return updateRecoveryConfig(request);
     }

--- a/powerauth-java-client-axis/src/main/resources/soap/wsdl/service-v3.wsdl
+++ b/powerauth-java-client-axis/src/main/resources/soap/wsdl/service-v3.wsdl
@@ -1341,6 +1341,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="allowMultipleRecoveryCodes" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="postcardPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
@@ -1356,6 +1357,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="allowMultipleRecoveryCodes" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>

--- a/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
@@ -1122,14 +1122,16 @@ public class PowerAuthServiceClient extends WebServiceGatewaySupport {
      * @param applicationId Application ID.
      * @param activationRecoveryEnabled Whether activation recovery is enabled.
      * @param postcardRecoveryEnabled Whether recovery postcard is enabled.
+     * @param allowMultipleRecoveryCodes Whether multiple recovery codes are allowed.
      * @param remoteRecoveryPublicKeyBase64 Base64 encoded remote public key.
      * @return Update recovery configuration response.
      */
-    public UpdateRecoveryConfigResponse updateRecoveryConfig(Long applicationId, Boolean activationRecoveryEnabled, Boolean recoveryPostcardEnabled, String remoteRecoveryPublicKeyBase64) {
+    public UpdateRecoveryConfigResponse updateRecoveryConfig(Long applicationId, Boolean activationRecoveryEnabled, Boolean recoveryPostcardEnabled, Boolean allowMultipleRecoveryCodes, String remoteRecoveryPublicKeyBase64) {
         UpdateRecoveryConfigRequest request = new UpdateRecoveryConfigRequest();
         request.setApplicationId(applicationId);
         request.setActivationRecoveryEnabled(activationRecoveryEnabled);
         request.setRecoveryPostcardEnabled(recoveryPostcardEnabled);
+        request.setAllowMultipleRecoveryCodes(allowMultipleRecoveryCodes);
         request.setRemotePostcardPublicKey(remoteRecoveryPublicKeyBase64);
         return updateRecoveryConfig(request);
     }

--- a/powerauth-java-client-spring/src/main/resources/soap/wsdl/service-v3.wsdl
+++ b/powerauth-java-client-spring/src/main/resources/soap/wsdl/service-v3.wsdl
@@ -1341,6 +1341,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="allowMultipleRecoveryCodes" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="postcardPublicKey" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
@@ -1356,6 +1357,7 @@
                         <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationRecoveryEnabled" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="recoveryPostcardEnabled" type="xs:boolean"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="allowMultipleRecoveryCodes" type="xs:boolean"/>
                         <xs:element maxOccurs="1" minOccurs="0" name="remotePostcardPublicKey" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/RecoveryServiceBehavior.java
@@ -568,6 +568,7 @@ public class RecoveryServiceBehavior {
         response.setApplicationId(applicationId);
         response.setActivationRecoveryEnabled(recoveryConfigEntity.getActivationRecoveryEnabled());
         response.setRecoveryPostcardEnabled(recoveryConfigEntity.getRecoveryPostcardEnabled());
+        response.setAllowMultipleRecoveryCodes(recoveryConfigEntity.getAllowMultipleRecoveryCodes());
         response.setPostcardPublicKey(recoveryConfigEntity.getRecoveryPostcardPublicKeyBase64());
         response.setRemotePostcardPublicKey(recoveryConfigEntity.getRemotePostcardPublicKeyBase64());
         return response;
@@ -612,6 +613,7 @@ public class RecoveryServiceBehavior {
             }
             recoveryConfigEntity.setActivationRecoveryEnabled(request.isActivationRecoveryEnabled());
             recoveryConfigEntity.setRecoveryPostcardEnabled(request.isRecoveryPostcardEnabled());
+            recoveryConfigEntity.setAllowMultipleRecoveryCodes(request.isAllowMultipleRecoveryCodes());
             if (request.getRemotePostcardPublicKey() != null) {
                 recoveryConfigEntity.setRemotePostcardPublicKeyBase64(request.getRemotePostcardPublicKey());
                 if (request.getRemotePostcardPublicKey().isEmpty()) {

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -1356,6 +1356,7 @@
                 <xs:element name="applicationId" type="xs:long" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="activationRecoveryEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="recoveryPostcardEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="allowMultipleRecoveryCodes" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="postcardPublicKey" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="remotePostcardPublicKey" type="xs:string" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
@@ -1371,6 +1372,7 @@
                 <xs:element name="applicationId" type="xs:long" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="activationRecoveryEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="recoveryPostcardEnabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="allowMultipleRecoveryCodes" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="remotePostcardPublicKey" type="xs:string" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>


### PR DESCRIPTION
Update of SOAP interface so that PowerAuth Admin can configure the `allowMultipleRecoveryCodes` option.