### PR TITLE
Fix #310: Reset failed attempts for recovery code when PUK is valid

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -1213,6 +1213,9 @@ public class ActivationServiceBehavior {
                 }
             }
 
+            // Reset failed count, PUK was valid
+            recoveryCodeEntity.setFailedAttempts(0L);
+
             // Change status of PUK which was used for recovery to USED
             pukUsedDuringActivation.setStatus(RecoveryPukStatus.USED);
             pukUsedDuringActivation.setTimestampLastChange(new Date());


### PR DESCRIPTION
I forgot about the reset of failed attempts.