### PR TITLE
Fix #319: Resolve advisories reported by OWASP check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.4.RELEASE</version>
+        <version>2.1.5.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -65,6 +65,14 @@
                     <artifactId>bcprov-jdk15on</artifactId>
                     <groupId>org.bouncycastle</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>ehcache</artifactId>
+                    <groupId>net.sf.ehcache</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                    <groupId>org.apache.geronimo.javamail</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
The resolution is:
- `tomcat-embed-core` is upgraded transitively by upgrading `spring-boot-starter-parent`
- `ehcache` is excluded as in previous release
- `geronimo-javamail` is excluded as in previous release
- issues in Spring boot security are related to Spring Framework `5.0.5`, see: https://pivotal.io/security/cve-2018-1258
- `jackson-databind` upgrade is risky, there is no version of `Spring Boot` released with fixed version, moreover the advisory does not apply to current usage (it requires `default typing` enabled and is only applicable to `MySQL`)