### PR TITLE
Fix #425: Exclude org.apache.xalan module for JBoss

### DIFF
--- a/powerauth-java-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/powerauth-java-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
 	<deployment>
+		<exclusions>
+			<module name="org.apache.xerces" />
+			<module name="org.apache.xalan" />
+		</exclusions>
 		<exclude-subsystems>
 			<!-- disable the logging subsystem because the application manages its own logging independently -->
 			<subsystem name="logging" />


### PR DESCRIPTION
This pull request excludes the problematic `org.apache.xalan` module together with the related `org.apache.xerces` module.

The Xalan library distributed with JBoss contains following bug:
https://issues.apache.org/jira/browse/XALANJ-2617

This bug has never been fixed in Xalan sources, although there were several attempts to fix it, such as this one:
https://github.com/apache/xalan-j/pull/4
Note that the pull request was done on a fork of original Xalan sources because the original project does not seem to be actively maintained.

Thus, the issue remains open in Wildfly/JBoss and causes problems when UTF-8 characters such as 🙎🏾‍♂️are used in PowerAuth SOAP responses:
https://issues.redhat.com/browse/WFLY-10166
https://issues.redhat.com/browse/JBEAP-14542

The bug is fixed in the JAXP libraries distributed with the JRE, the JRE contains a complete Xalan library distribution which is more up-to-date.

By excluding the problematic `org.apache.xalan` module, the JAXP runtime should use the fixed implementation from the JRE which is always available. We could also specify the factory using `javax.xml.transform.TransformerFactory` as `com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl` in `META-INF/services`, however tests on Wildfly show that excluding the module is enough to resolve the issue and it is a lesser evil to exclude the problematic module than to force a very specific JAXP configuration. 

The `org.apache.xerces` module is excluded as well because its latest implementation is also available in the JRE.