### PR TITLE
Fix #432: Configure TransformerFactory for JBoss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.getlime.security</groupId>
     <artifactId>powerauth-server-parent</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/powerauth-java-client-axis/pom.xml
+++ b/powerauth-java-client-axis/pom.xml
@@ -22,14 +22,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>powerauth-java-client-axis</artifactId>
-	<version>0.24.0</version>
+	<version>0.25.0-SNAPSHOT</version>
 	<name>powerauth-java-client-axis</name>
 	<description>PowerAuth Server SOAP Service Client - Axis</description>
 
 	<parent>
 		<groupId>io.getlime.security</groupId>
 		<artifactId>powerauth-server-parent</artifactId>
-		<version>0.24.0</version>
+		<version>0.25.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/powerauth-java-client-spring/pom.xml
+++ b/powerauth-java-client-spring/pom.xml
@@ -22,14 +22,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powerauth-java-client-spring</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <name>powerauth-java-client-spring</name>
     <description>PowerAuth Server SOAP Service Client</description>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -24,13 +24,13 @@
     <name>powerauth-java-server</name>
     <description>PowerAuth Server</description>
     <artifactId>powerauth-java-server</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/powerauth-java-server/src/main/webapp/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/powerauth-java-server/src/main/webapp/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,0 +1,1 @@
+com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl


### PR DESCRIPTION
The following fix of `TransformerFactory` will avoid the UTF-8 surrogate character transformation bug in Xalan when another factory is set in the application server.