### PR TITLE
Fix #520: Cannot determine datatype error in JPA for Postgres

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
@@ -160,11 +160,11 @@ public interface ActivationRepository extends CrudRepository<ActivationRecordEnt
      * Find all activations which match the query criteria.
      * @param userIds List of user IDs, at least one user ID should be specified.
      * @param applicationIds List of application IDs, use null value for all applications.
-     * @param timestampLastUsedBefore Last used timestamp (timestampLastUsed &lt; timestampLastUsedBefore), use null value for any date.
-     * @param timestampLastUsedAfter Last used timestamp (timestampLastUsed &gt;= timestampLastUsedAfter), use null value for any date.
+     * @param timestampLastUsedBefore Last used timestamp (timestampLastUsed &lt; timestampLastUsedBefore), use the 1.1.9999 value for any date (null date values in query cause problems in PostgreSQL).
+     * @param timestampLastUsedAfter Last used timestamp (timestampLastUsed &gt;= timestampLastUsedAfter), use the 1.1.1970 value for any date (null date values in query cause problems in PostgreSQL).
      * @param states List of activation states to consider.
      * @return List of activations which match the query criteria.
      */
-    @Query("SELECT a FROM ActivationRecordEntity a WHERE a.userId IN :userIds AND (:applicationIds IS NULL OR a.application.id IN :applicationIds) AND (:timestampLastUsedBefore IS NULL OR a.timestampLastUsed < :timestampLastUsedBefore) AND (:timestampLastUsedAfter IS NULL OR a.timestampLastUsed >= :timestampLastUsedAfter) AND a.activationStatus IN :states")
+    @Query("SELECT a FROM ActivationRecordEntity a WHERE a.userId IN :userIds AND (:applicationIds IS NULL OR a.application.id IN :applicationIds) AND a.timestampLastUsed < :timestampLastUsedBefore AND a.timestampLastUsed >= :timestampLastUsedAfter AND a.activationStatus IN :states")
     List<ActivationRecordEntity> lookupActivations(Collection<String> userIds, Collection<Long> applicationIds, Date timestampLastUsedBefore, Date timestampLastUsedAfter, Collection<ActivationStatus> states);
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ActivationServiceBehavior.java
@@ -278,8 +278,8 @@ public class ActivationServiceBehavior {
      *
      * @param userIds User IDs to be used in the activations query.
      * @param applicationIds Application IDs to be used in the activations query (optional).
-     * @param timestampLastUsedBefore Last used timestamp to be used in the activations query, return all records where timestampLastUsed &lt; timestampLastUsedBefore (optional).
-     * @param timestampLastUsedAfter Last used timestamp to be used in the activations query, return all records where timestampLastUsed &gt;= timestampLastUsedAfter (optional).
+     * @param timestampLastUsedBefore Last used timestamp to be used in the activations query, return all records where timestampLastUsed &lt; timestampLastUsedBefore.
+     * @param timestampLastUsedAfter Last used timestamp to be used in the activations query, return all records where timestampLastUsed &gt;= timestampLastUsedAfter.
      * @param activationStatus Activation status to be used in the activations query (optional).
      * @return Response with list of matching activations.
      * @throws DatatypeConfigurationException If calendar conversion fails.

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -62,6 +62,12 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     private final ActivationStatusConverter activationStatusConverter = new ActivationStatusConverter();
 
+    // Minimum date for SQL timestamps: 01/01/1970 @ 12:00am (UTC)
+    private static final Date MIN_TIMESTAMP = new Date(1L);
+
+    // Maximum date for SQL timestamps: 01/01/9999 @ 12:00am (UTC)
+    private static final Date MAX_TIMESTAMP = new Date(253370764800000L);
+
     // Prepare logger
     private static final Logger logger = LoggerFactory.getLogger(PowerAuthServiceImpl.class);
 
@@ -161,13 +167,17 @@ public class PowerAuthServiceImpl implements PowerAuthService {
         try {
             List<String> userIds = request.getUserIds();
             List<Long> applicationIds = request.getApplicationIds();
-            Date timestampLastUsedBefore = null;
+            Date timestampLastUsedBefore;
             if (request.getTimestampLastUsedBefore() != null) {
                 timestampLastUsedBefore = XMLGregorianCalendarConverter.convertTo(request.getTimestampLastUsedBefore());
+            } else {
+                timestampLastUsedBefore = MAX_TIMESTAMP;
             }
-            Date timestampLastUsedAfter = null;
+            Date timestampLastUsedAfter;
             if (request.getTimestampLastUsedAfter() != null) {
                 timestampLastUsedAfter = XMLGregorianCalendarConverter.convertTo(request.getTimestampLastUsedAfter());
+            } else {
+                timestampLastUsedAfter = MIN_TIMESTAMP;
             }
             ActivationStatus activationStatus = null;
             if (request.getActivationStatus() != null) {


### PR DESCRIPTION
It is not possible to use `null` values in dates for Postgres without a cast in JPQL. A cast could lead to incompatibilities, so I use minimum and maximum values for dates instead. I will test the `1.1.9999` date on other databases, too, it should be valid based on the SQL standard.