### PR TITLE
Fix #516: Improve documentation for REST API

### DIFF
--- a/docs/Configuring-SOAP-Client-for-Axis2.md
+++ b/docs/Configuring-SOAP-Client-for-Axis2.md
@@ -78,4 +78,4 @@ You can access the WSDL files in following URLs:
 
 ## Using the SOAP Service Client
 
-In order to use SOAP service client, follow our [generic SOAP client service documentation](./SOAP-Client-Library-Usage.md) and read the [reference manual](./SOAP-Service-Methods.md).
+In order to use SOAP service client, follow our [generic SOAP client service documentation](./SOAP-Client-Library-Usage.md) and read the [reference manual](WebServices-Methods.md).

--- a/docs/Configuring-SOAP-Client-for-Spring.md
+++ b/docs/Configuring-SOAP-Client-for-Spring.md
@@ -130,4 +130,4 @@ You can access the WSDL files in following URLs:
 
 ## Using the SOAP Service Client
 
-In order to use SOAP service client, follow our [generic SOAP client service documentation](./SOAP-Client-Library-Usage.md) and read the [reference manual](./SOAP-Service-Methods.md).
+In order to use SOAP service client, follow our [generic SOAP client service documentation](./SOAP-Client-Library-Usage.md) and read the [reference manual](WebServices-Methods.md).

--- a/docs/Deploying-PowerAuth-Server.md
+++ b/docs/Deploying-PowerAuth-Server.md
@@ -92,7 +92,7 @@ powerauth.service.applicationDisplayName=PowerAuth Server
 powerauth.service.applicationEnvironment=
 ```
 
-These properties are returned when calling the `getSystemStatus` method of the SOAP interface.
+These properties are returned when calling the `/rest/v3/status` / `getSystemStatus` method of the REST / SOAP interface.
 
 ## Enabling PowerAuth Server Security
 

--- a/docs/Offline-Signatures.md
+++ b/docs/Offline-Signatures.md
@@ -11,7 +11,7 @@ The following endpoints are available for offline signatures:
 
 Personalized offline signatures are used when activation ID is known (e.g. an activated mobile token). A typical use case is offline verification of signature for payments.
 
-SOAP method: [createPersonalizedOfflineSignaturePayload](./SOAP-Service-Methods.md#method-createpersonalizedofflinesignaturepayload)
+REST / SOAP method: [createPersonalizedOfflineSignaturePayload](WebServices-Methods.md#method-createpersonalizedofflinesignaturepayload)
 
 For Web Flow the format of request `data` is documented in the [Offline Signatures QR Code](https://github.com/wultra/powerauth-webflow/blob/develop/docs/Off-line-Signatures-QR-Code.md) documentation chapter.
 
@@ -21,7 +21,7 @@ The `offlineData` in response already contains all data required to display a QR
 
 Non-personalized offline signatures are used when activation ID is not known. A typical use case is offline verification for login operation.
 
-SOAP method: [createNonPersonalizedOfflineSignaturePayload](./SOAP-Service-Methods.md#method-createpersonalizedofflinesignaturepayload)
+REST / SOAP method: [createNonPersonalizedOfflineSignaturePayload](WebServices-Methods.md#method-createpersonalizedofflinesignaturepayload)
 
 For Web Flow the format of request `data` is documented in the [Offline Signatures QR Code](https://github.com/wultra/powerauth-webflow/blob/develop/docs/Off-line-Signatures-QR-Code.md) documentation chapter.
 
@@ -31,7 +31,7 @@ The `offlineData` in response already contains all data required to display a QR
 
 Once the mobile device successfully scans the QR code and verifies the QR code data signature, the signature of the data related to the operation can be computed as described in [Computing and Validating Signatures](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Computing-and-Validating-Signatures.md). The generated signature can be verified against PowerAuth server.
 
-SOAP method: [verifyOfflineSignature](./SOAP-Service-Methods.md#method-verifyofflinesignature)
+REST / SOAP method: [verifyOfflineSignature](WebServices-Methods.md#method-verifyofflinesignature)
 
 The normalized `data` for verifyOfflineSignature requests should be constructed as described in [Normalized data for HTTP requests](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Computing-and-Validating-Signatures.md#normalized-data-for-http-requests). The `nonce` generated in the generate offline signature payload step should be used.
 

--- a/docs/PowerAuth-Server-0.21.0.md
+++ b/docs/PowerAuth-Server-0.21.0.md
@@ -180,7 +180,7 @@ The PowerAuth protocol upgrade caused following changes in PowerAuth server impl
 The original `v2` interfaces are still available both in the SOAP API, REST API and both client implementations, however migration to new interfaces is recommended. 
 The `v2` interfaces will be deprecated in a future release. 
 
-The interface changes are described in details in chapter [SOAP Method Compatibility](./SOAP-Method-Compatibility.md).
+The interface changes are described in details in chapter [Web Services - Method Compatibility](WebServices-Method-Compatibility.md).
 
 ### JAXB Marshaller Context Path Update
 
@@ -215,7 +215,7 @@ Note that the namespaces reflect the WSDL version:
 - version `3`: http://getlime.io/security/powerauth/v3
 - version `2`: http://getlime.io/security/powerauth/v2
 
-The interface changes are described in details in chapter [SOAP Method Compatibility](./SOAP-Method-Compatibility.md).
+The interface changes are described in details in chapter [SOAP Method Compatibility](WebServices-Method-Compatibility.md).
 
 ### Client API Changes
 
@@ -225,7 +225,7 @@ The version `3` methods are available as default implementation directly on the 
 
 You can access the version `2` specific methods using the `v2()` method in the client. This method will be deprecated in a future release.
 
-The interface changes are described in details in chapter [SOAP Method Compatibility](./SOAP-Method-Compatibility.md).
+The interface changes are described in details in chapter [SOAP Method Compatibility](WebServices-Method-Compatibility.md).
 
 ### Activation Short ID Change to Activation Code
 

--- a/docs/PowerAuth-Server-0.21.0.md
+++ b/docs/PowerAuth-Server-0.21.0.md
@@ -215,7 +215,7 @@ Note that the namespaces reflect the WSDL version:
 - version `3`: http://getlime.io/security/powerauth/v3
 - version `2`: http://getlime.io/security/powerauth/v2
 
-The interface changes are described in details in chapter [SOAP Method Compatibility](WebServices-Method-Compatibility.md).
+The interface changes are described in details in chapter [Web Services - Method Compatibility](WebServices-Method-Compatibility.md).
 
 ### Client API Changes
 
@@ -225,7 +225,7 @@ The version `3` methods are available as default implementation directly on the 
 
 You can access the version `2` specific methods using the `v2()` method in the client. This method will be deprecated in a future release.
 
-The interface changes are described in details in chapter [SOAP Method Compatibility](WebServices-Method-Compatibility.md).
+The interface changes are described in details in chapter [Web Services - Method Compatibility](WebServices-Method-Compatibility.md).
 
 ### Activation Short ID Change to Activation Code
 

--- a/docs/PowerAuth-Server-0.22.0.md
+++ b/docs/PowerAuth-Server-0.22.0.md
@@ -308,12 +308,12 @@ After [fixing the Spring bean naming conventions](https://github.com/wultra/powe
 
 ### Offline Signatures and Biometry
 
-The [VerifyOfflineSignature](./SOAP-Service-Methods.md#method-verifyofflinesignature) method has been updated to specify whether biometry is allowed in offline mode instead of specifying the used signature type directly. The PowerAuth client `verifyOfflineSignature` method has been updated to reflect the change of parameters. If you use offline mode verification using PowerAuth API, please update the SOAP method call.
+The [VerifyOfflineSignature](WebServices-Methods.md#method-verifyofflinesignature) method has been updated to specify whether biometry is allowed in offline mode instead of specifying the used signature type directly. The PowerAuth client `verifyOfflineSignature` method has been updated to reflect the change of parameters. If you use offline mode verification using PowerAuth API, please update the SOAP method call.
 
 ### External User Identifier
 
-The [CommitActivation](./SOAP-Service-Methods.md#method-commitactivation), [RemoveActivation](./SOAP-Service-Methods.md#method-removeactivation), [BlockActivation](./SOAP-Service-Methods.md#method-blockactivation) and [UnblockActivation](./SOAP-Service-Methods.md#method-unblockactivation) methods have been updated to allow specification of external user identifier. The related PowerAuth client methods have been updated to reflect the change of parameters. If you use any of these methods, please update the SOAP method call.
+The [CommitActivation](WebServices-Methods.md#method-commitactivation), [RemoveActivation](WebServices-Methods.md#method-removeactivation), [BlockActivation](WebServices-Methods.md#method-blockactivation) and [UnblockActivation](WebServices-Methods.md#method-unblockactivation) methods have been updated to allow specification of external user identifier. The related PowerAuth client methods have been updated to reflect the change of parameters. If you use any of these methods, please update the SOAP method call.
 
 ### Revoking Recovery Codes on Activation Removal
 
-We added an optional `revokeRecoveryCodes` attribute to [activation removal service call](./SOAP-Service-Methods.md#method-removeactivation). This flag indicates if recovery codes that are associated with removed activation should be also revoked. By default, the value of the flag is `false`, hence omitting the flag results in the same behavior as before this change. 
+We added an optional `revokeRecoveryCodes` attribute to [activation removal service call](WebServices-Methods.md#method-removeactivation). This flag indicates if recovery codes that are associated with removed activation should be also revoked. By default, the value of the flag is `false`, hence omitting the flag results in the same behavior as before this change. 

--- a/docs/PowerAuth-Server-0.23.0.md
+++ b/docs/PowerAuth-Server-0.23.0.md
@@ -102,4 +102,4 @@ If you turned on additional database record encryption in any previous PowerAuth
 
 ### Revoking Recovery Codes on Activation Removal
 
-We added an optional `revokeRecoveryCodes` attribute to [activation removal service call](./SOAP-Service-Methods.md#method-removeactivation). This flag indicates if recovery codes that are associated with removed activation should be also revoked. By default, the value of the flag is `false`, hence omitting the flag results in the same behavior as before this change. 
+We added an optional `revokeRecoveryCodes` attribute to [activation removal service call](WebServices-Methods.md#method-removeactivation). This flag indicates if recovery codes that are associated with removed activation should be also revoked. By default, the value of the flag is `false`, hence omitting the flag results in the same behavior as before this change. 

--- a/docs/PowerAuth-Server-0.24.0.md
+++ b/docs/PowerAuth-Server-0.24.0.md
@@ -83,7 +83,7 @@ Check [Additional Activation OTP](https://github.com/wultra/powerauth-crypto/blo
 
 ### Revoking Recovery Codes on Activation Removal
 
-We added an optional `revokeRecoveryCodes` attribute to [activation removal service call](./SOAP-Service-Methods.md#method-removeactivation). This flag indicates if recovery codes that are associated with removed activation should be also revoked. By default, the value of the flag is `false`, hence omitting the flag results in the same behavior as before this change. 
+We added an optional `revokeRecoveryCodes` attribute to [activation removal service call](WebServices-Methods.md#method-removeactivation). This flag indicates if recovery codes that are associated with removed activation should be also revoked. By default, the value of the flag is `false`, hence omitting the flag results in the same behavior as before this change. 
 
 ## RESTful integration Changes
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -18,7 +18,7 @@ PowerAuth Server is a Java EE application (packaged as an executable WAR file) r
 
 ## Reference Manual
 
-- [SOAP Interface Methods](WebServices-Methods.md)
+- [Web Services - Methods](WebServices-Methods.md)
 - [PowerAuth Server Database Structure](./Database-Structure.md)
 - [PowerAuth Server Error Codes](./Server-Error-Codes.md)
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -10,7 +10,7 @@ PowerAuth Server is a Java EE application (packaged as an executable WAR file) r
 
 ## Integration Tutorials
 
-- [Introduction](./Using-SOAP-Service-Client.md)
+- [Introduction](WebServices-Client.md)
 - [Configuring REST Client (Spring)](./Configuring-REST-Client-for-Spring.md)
 - [Configuring SOAP Client (Spring WS)](./Configuring-SOAP-Client-for-Spring.md)
 - [Configuring SOAP Client (Axis2)](./Configuring-SOAP-Client-for-Axis2.md)
@@ -18,7 +18,7 @@ PowerAuth Server is a Java EE application (packaged as an executable WAR file) r
 
 ## Reference Manual
 
-- [SOAP Interface Methods](./SOAP-Service-Methods.md)
+- [SOAP Interface Methods](WebServices-Methods.md)
 - [PowerAuth Server Database Structure](./Database-Structure.md)
 - [PowerAuth Server Error Codes](./Server-Error-Codes.md)
 

--- a/docs/SOAP-Client-Library-Usage.md
+++ b/docs/SOAP-Client-Library-Usage.md
@@ -8,7 +8,7 @@ The SOAP client supports two versions of PowerAuth protocol:
 - The version `3` methods are available as default implementation directly on the client class. 
 - You can access the version `2` specific methods using the `v2()` method in the client. This method will be deprecated in a future release.
 
-All samples in this chapter use the version `3` client methods. See chapter [SOAP Method Compatibility](./SOAP-Method-Compatibility.md) for additional details about SOAP interface versioning.
+All samples in this chapter use the version `3` client methods. See chapter [SOAP Method Compatibility](WebServices-Method-Compatibility.md) for additional details about SOAP interface versioning.
 
 ## Obtaining the New Activation Data
 

--- a/docs/SOAP-Client-Library-Usage.md
+++ b/docs/SOAP-Client-Library-Usage.md
@@ -8,7 +8,7 @@ The SOAP client supports two versions of PowerAuth protocol:
 - The version `3` methods are available as default implementation directly on the client class. 
 - You can access the version `2` specific methods using the `v2()` method in the client. This method will be deprecated in a future release.
 
-All samples in this chapter use the version `3` client methods. See chapter [SOAP Method Compatibility](WebServices-Method-Compatibility.md) for additional details about SOAP interface versioning.
+All samples in this chapter use the version `3` client methods. See chapter [Web Services - Method Compatibility](WebServices-Method-Compatibility.md) for additional details about SOAP interface versioning.
 
 ## Obtaining the New Activation Data
 

--- a/docs/WebServices-Client.md
+++ b/docs/WebServices-Client.md
@@ -1,6 +1,10 @@
-# Using SOAP Service Client
+# Using REST / SOAP Service Client
 
 PowerAuth assumes that the end-user client application (for example, mobile banking) is managed via a secure "master front-end application", for example via the Internet banking. Internet banking has to display a page to the user with the device activation list and allow user to create a new activation and manage existing activations.
+
+In order to integrate your web application with REST services provided by PowerAuth Server, follow this tutorial:
+
+- [Configuring REST Client for Spring](./Configuring-REST-Client-for-Spring.md)
 
 In order to integrate your web application with SOAP services provided by PowerAuth Server, follow this tutorial:
 

--- a/docs/WebServices-Method-Compatibility.md
+++ b/docs/WebServices-Method-Compatibility.md
@@ -1,6 +1,6 @@
-# SOAP Method Compatibility
+# Web Services - Method Compatibility
 
-This chapter describes SOAP interface changes per each SOAP method between PowerAuth protocol versions `2` and `3`. 
+This chapter describes REST / SOAP interface changes per each REST / SOAP method between PowerAuth protocol versions `2` and `3`. 
 The table below lists which methods are available for each version of PowerAuth protocol and describes how to handle the interface change.
 
 | Method                      | `v2` | `v3` | Compatibility issues | Migration notes |

--- a/docs/WebServices-Methods.md
+++ b/docs/WebServices-Methods.md
@@ -1,12 +1,16 @@
-# SOAP Service Methods
+# Web Services - Methods
 
-This is a reference documentation of the methods published by the PowerAuth Server SOAP service.
-It reflects the SOAP service methods as they are defined in the WSDL files:
+This is a reference documentation of the methods published by the PowerAuth Server REST / SOAP services.
+
+The REST service methods can be browsed using Swagger on deployed PowerAuth instance:
+- http://localhost:8080/powerauth-java-server/swagger-ui.html
+
+SOAP service methods are defined in the WSDL files:
 
 - [serviceV3.wsdl](../powerauth-java-client-spring/src/main/resources/soap/wsdl/serviceV3.wsdl)
 - [serviceV2.wsdl](../powerauth-java-client-spring/src/main/resources/soap/wsdl/serviceV2.wsdl)
 
-The versioning of SOAP methods is described in chapter [SOAP Method Compatibility](./SOAP-Method-Compatibility.md).
+The versioning of SOAP methods is described in chapter [Web Services - Method Compatibility](WebServices-Method-Compatibility.md).
 
 The following `v3` methods are published using the service:
 
@@ -106,6 +110,8 @@ Get the server status information.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/status`
+
 `GetSystemStatusRequest`
 
 - _no attributes_
@@ -129,6 +135,8 @@ Get the server status information.
 Get the list of all error codes that PowerAuth Server can return.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/error/list`
 
 `GetErrorCodeListRequest`
 
@@ -161,6 +169,8 @@ Get list of all applications that are present in this PowerAuth Server instance.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/list`
+
 `GetApplicationListRequest`
 
 - _no attributes_
@@ -186,6 +196,8 @@ Get list of all applications that are present in this PowerAuth Server instance.
 Get detail of application with given ID or name, including the list of versions.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/detail`
 
 `GetApplicationDetailRequest`
 
@@ -223,6 +235,8 @@ Find application using application key.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/detail/version`
+
 `LookupApplicationByAppKeyRequest`
 
 | Type | Name | Description |
@@ -242,6 +256,8 @@ Find application using application key.
 Create a new application with given name.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/create`
 
 `CreateApplicationRequest`
 
@@ -264,6 +280,8 @@ Create a new application with given name.
 Create a new application version with given name for a specified application.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/version/create`
 
 `CreateApplicationVersionRequest`
 
@@ -290,6 +308,8 @@ Mark application version with given ID as "unsupported". Signatures constructed 
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/version/unsupport`
+
 `UnsupportApplicationVersionRequest`
 
 | Type | Name | Description |
@@ -310,6 +330,8 @@ Mark application version with given ID as "unsupported". Signatures constructed 
 Mark application version with given ID as "supported". Signatures constructed using application key and application secret associated with this versions will be evaluated the standard way.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/version/support`
 
 `SupportApplicationVersionRequest`
 
@@ -337,6 +359,8 @@ Create (initialize) a new activation for given user and application. If both `ac
 After calling this method, a new activation record is created in CREATED state.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/init`
 
 `InitActivationRequest`
 
@@ -377,6 +401,8 @@ After successfully calling this method, activation is in PENDING_COMMIT or ACTIV
 | OTP is required, but is not valid, no attempts left | `REMOVED`        |
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/prepare`
 
 `PrepareActivationRequest`
 
@@ -427,6 +453,8 @@ After successfully calling this method, activation is in PENDING_COMMIT state.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/create`
+
 `CreateActivationRequest`
 
 | Type | Name | Description |
@@ -474,6 +502,8 @@ After successful, activation OTP is updated and the OTP validation is set to ON_
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/otp/update`
+
 `UpdateActivationOtpRequest`
 
 | Type | Name | Description |
@@ -501,6 +531,8 @@ After successful commit, activation is in ACTIVE state.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/commit`
+
 `CommitActivationRequest`
 
 | Type | Name | Description |
@@ -523,6 +555,8 @@ After successful commit, activation is in ACTIVE state.
 Get status information and all important details for activation with given ID.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/status`
 
 `GetActivationStatusRequest`
 
@@ -562,6 +596,8 @@ Remove activation with given ID. This operation is irreversible. Activations can
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/remove`
+
 `RemoveActivationRequest`
 
 | Type | Name | Description |
@@ -584,6 +620,8 @@ Remove activation with given ID. This operation is irreversible. Activations can
 Get the list of all activations for given user and application ID. If no application ID is provided, return list of all activations for given user.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/list`
 
 `GetActivationListForUserRequest`
 
@@ -627,6 +665,8 @@ Block activation with given ID. Activations can be blocked in ACTIVE state only.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/block`
+
 `BlockActivationRequest`
 
 | Type | Name | Description |
@@ -651,6 +691,8 @@ Unblock activation with given ID. Activations can be unblocked in BLOCKED state 
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/unblock`
+
 `UnblockActivationRequest`
 
 | Type | Name | Description |
@@ -672,6 +714,8 @@ Unblock activation with given ID. Activations can be unblocked in BLOCKED state 
 Lookup activations using query parameters.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/lookup`
 
 `LookupActivationsRequest`
 
@@ -716,6 +760,8 @@ Update status for activations identified using their identifiers.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/status/update`
+
 `UpdateStatusForActivationsRequest`
 
 | Type | Name | Description |
@@ -740,6 +786,8 @@ Methods related to signature verification.
 Verify signature correctness for given activation, application key, data and signature type.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/signature/verify`
 
 `VerifySignatureRequest`
 
@@ -773,6 +821,8 @@ Verify asymmetric ECDSA signature correctness for given activation and data.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/verifyECDSASignature`
+
 `VerifyECDSASignatureRequest`
 
 | Type | Name | Description |
@@ -794,6 +844,8 @@ Verify asymmetric ECDSA signature correctness for given activation and data.
 Create a data payload used as a challenge for personalized off-line signatures.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/signature/offline/personalized/create`
 
 `CreatePersonalizedOfflineSignaturePayloadRequest`
 
@@ -817,6 +869,8 @@ Create a data payload used as a challenge for non-personalized off-line signatur
 
 #### Request
 
+REST endpoint: `POST /rest/v3/signature/offline/non-personalized/create`
+
 `CreateNonPersonalizedOfflineSignaturePayloadRequest`
 
 | Type | Name | Description |
@@ -838,6 +892,8 @@ Create a data payload used as a challenge for non-personalized off-line signatur
 Verify off-line signature of provided data.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/signature/offline/verify`
 
 `VerifyOfflineSignatureRequest`
 
@@ -870,6 +926,8 @@ Verify off-line signature of provided data.
 Create a new token for the simple token-based authentication.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/token/create`
 
 `CreateTokenRequest`
 
@@ -911,6 +969,8 @@ Validate token digest used for the simple token-based authentication.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/token/validate`
+
 `ValidateTokenRequest`
 
 | Type | Name | Description |
@@ -938,6 +998,8 @@ Remove token with given ID.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/token/remove`
+
 `RemoveTokenRequest`
 
 | Type | Name | Description |
@@ -961,6 +1023,8 @@ Methods related to secure vault.
 Get the encrypted vault unlock key upon successful authentication using PowerAuth Signature.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/vault/unlock`
 
 `VaultUnlockRequest`
 
@@ -1019,6 +1083,8 @@ Get the signature audit log for given user, application and date range. In case 
 
 #### Request
 
+REST endpoint: `POST /rest/v3/signature/list`
+
 `SignatureAuditRequest`
 
 | Type | Name | Description |
@@ -1066,6 +1132,8 @@ Get the status change log for given activation and date range.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/history`
+
 `ActivationHistoryRequest`
 
 | Type | Name | Description |
@@ -1103,6 +1171,8 @@ Create a new integration with given name, automatically generate credentials for
 
 #### Request
 
+REST endpoint: `POST /rest/v3/integration/create`
+
 `CreateIntegrationRequest`
 
 | Type | Name | Description |
@@ -1125,6 +1195,8 @@ Create a new integration with given name, automatically generate credentials for
 Get the list of all integrations that are configured on the server instance.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/integration/list`
 
 `GetIntegrationListRequest`
 
@@ -1153,6 +1225,8 @@ Remove integration with given ID.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/integration/remove`
+
 `RemoveIntegrationRequest`
 
 | Type | Name | Description |
@@ -1173,6 +1247,8 @@ Remove integration with given ID.
 Create a callback URL with given parameters.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/callback/create`
 
 `CreateCallbackUrlRequest`
 
@@ -1212,6 +1288,8 @@ Update a callback URL with given parameters.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/callback/update`
+
 `UpdateCallbackUrlRequest`
 
 | Type | Name | Description |
@@ -1250,6 +1328,8 @@ Get the list of all callbacks for given application.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/callback/list`
+
 `GetCallbackUrlListRequest`
 
 | Type | Name | Description |
@@ -1280,6 +1360,8 @@ Remove callback URL with given ID.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/callback/remove`
+
 `RemoveCallbackUrlRequest`
 
 | Type | Name | Description |
@@ -1302,6 +1384,8 @@ Remove callback URL with given ID.
 Get ECIES decryptor data for request/response decryption on intermediate server.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/ecies/decryptor`
 
 `GetEciesDecryptorRequest`
 
@@ -1328,6 +1412,8 @@ Upgrade activation to the most recent version supported by the server.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/upgrade/start`
+
 `StartUpgradeRequest`
 
 | Type | Name | Description |
@@ -1350,9 +1436,11 @@ Upgrade activation to the most recent version supported by the server.
 
 ### Method 'commitUpgrade'
 
-Commint activation upgrade.
+Commit activation upgrade.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/upgrade/commit`
 
 `CommitUpgradeRequest`
 
@@ -1376,6 +1464,8 @@ Commint activation upgrade.
 Create a recovery code for user.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/recovery/create`
 
 `CreateRecoveryCodeRequest`
 
@@ -1412,6 +1502,8 @@ Confirm a recovery code recieved using recovery postcard.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/recovery/confirm`
+
 `ConfirmRecoveryCodeRequest`
 
 | Type | Name | Description |
@@ -1445,6 +1537,8 @@ ECIES response contains following data (as JSON):
 Lookup recovery codes.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/recovery/lookup`
 
 `LookupRecoveryCodesRequest`
 
@@ -1483,6 +1577,8 @@ Revoke recovery codes.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/recovery/revoke`
+
 `RevokeRecoveryCodesRequest`
 
 | Type | Name | Description |
@@ -1504,6 +1600,8 @@ Create an activation using recovery code. After successfully calling this method
 If optional `activationOtp` value is set, then the activation's OTP validation mode is set to `ON_COMMIT`. The same OTP value must be later provided in [CommitActivation](#method-commitactivation) method, to complete the activation.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/recovery/create`
 
 `RecoveryCodeActivationRequest`
 
@@ -1554,6 +1652,8 @@ Get configuration of activation recovery.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/recovery/config/detail`
+
 `GetRecoveryConfigRequest`
 
 | Type | Name | Description |
@@ -1579,6 +1679,8 @@ Update configuration of activation recovery.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/recovery/config/update`
+
 `UpdateRecoveryConfigRequest`
 
 | Type | Name | Description |
@@ -1603,6 +1705,8 @@ List flags for an activation.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/flags/list`
+
 `ListActivationFlagsRequest`
 
 | Type | Name | Description |
@@ -1623,6 +1727,8 @@ List flags for an activation.
 Add activation flags to an activation. Duplicate flags are ignored.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/flags/create`
 
 `AddActivationFlagsRequest`
 
@@ -1646,6 +1752,8 @@ Update activation flags to an activation. Existing flags are removed.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/activation/flags/update`
+
 `UpdateActivationFlagsRequest`
 
 | Type | Name | Description |
@@ -1667,6 +1775,8 @@ Update activation flags to an activation. Existing flags are removed.
 Remove activation flags for an activation.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/activation/flags/remove`
 
 `RemoveActivationFlagsRequest`
 
@@ -1690,6 +1800,8 @@ List roles for an application.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/roles/list`
+
 `ListApplicationRolesRequest`
 
 | Type | Name | Description |
@@ -1710,6 +1822,8 @@ List roles for an application.
 Add application roles to an application. Duplicate roles are ignored.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/roles/create`
 
 `AddApplicationRolesRequest`
 
@@ -1733,6 +1847,8 @@ Update application roles assigned to an application. Existing roles are removed.
 
 #### Request
 
+REST endpoint: `POST /rest/v3/application/roles/update`
+
 `UpdateApplicationRolesRequest`
 
 | Type | Name | Description |
@@ -1749,11 +1865,13 @@ Update application roles assigned to an application. Existing roles are removed.
 | `Long` | `applicationId` | The identifier of the application |
 | `String[]` | `applicationRoles` | Application roles assigned to the application after the update |
 
-### Method `removeApplicationFlags`
+### Method `removeApplicationRoles`
 
 Remove application roles from an activation.
 
 #### Request
+
+REST endpoint: `POST /rest/v3/application/roles/remove`
 
 `RemoveApplicationRolesRequest`
 
@@ -1779,6 +1897,8 @@ Remove application roles from an activation.
 Assure a key exchange between PowerAuth Client and PowerAuth Server and prepare the activation with given ID to be committed. Only activations in CREATED state can be prepared. After successfully calling this method, activation is in PENDING_COMMIT state.
 
 #### Request
+
+REST endpoint: `POST /rest/v2/activation/prepare`
 
 `PrepareActivationRequest`
 
@@ -1810,6 +1930,8 @@ Assure a key exchange between PowerAuth Client and PowerAuth Server and prepare 
 Create an activation for given user and application, with provided maximum number of failed attempts and expiration timestamp, including a key exchange between PowerAuth Client and PowerAuth Server. Prepare the activation to be committed later. After successfully calling this method, activation is in PENDING_COMMIT state.
 
 #### Request
+
+REST endpoint: `POST /rest/v2/activation/create`
 
 `CreateActivationRequest`
 
@@ -1848,6 +1970,8 @@ Create a new token for the simple token-based authentication.
 
 #### Request
 
+REST endpoint: `POST /rest/v2/token/create`
+
 `CreateTokenRequest`
 
 | Type | Name | Description |
@@ -1872,6 +1996,8 @@ Create a new token for the simple token-based authentication.
 Get the encrypted vault unlock key upon successful authentication using PowerAuth Signature.
 
 #### Request
+
+REST endpoint: `POST /rest/v2/vault/unlock`
 
 `VaultUnlockRequest`
 
@@ -1908,6 +2034,8 @@ Establishes a context required for performing a non-personalized (application sp
 
 #### Request
 
+REST endpoint: `POST /rest/v2/application/encryption/key/create`
+
 `GetNonPersonalizedEncryptionKeyRequest`
 
 | Type | Name | Description |
@@ -1933,6 +2061,8 @@ Establishes a context required for performing a non-personalized (application sp
 Establishes a context required for performing a personalized (activation specific) end-to-end encryption.
 
 #### Request
+
+REST endpoint: `POST /rest/v2/activation/encryption/key/create`
 
 `GetPersonalizedEncryptionKeyRequest`
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -7,7 +7,7 @@
 
 **Integration Tutorials**
 
-- [Introduction](./Using-SOAP-Service-Client.md)
+- [Introduction](WebServices-Client.md)
 - [Configuring REST Client (Spring)](./Configuring-REST-Client-for-Spring.md)
 - [SOAP Client (Spring WS)](./Configuring-SOAP-Client-for-Spring.md)
 - [SOAP Client (Axis2)](./Configuring-SOAP-Client-for-Axis2.md)
@@ -15,7 +15,7 @@
 
 **Reference Manual**
 
-- [SOAP Interface Methods](./SOAP-Service-Methods.md)
+- [Web Services - Methods](WebServices-Methods.md)
 - [Database Structure](./Database-Structure.md)
 - [Error Codes](./Server-Error-Codes.md)
 


### PR DESCRIPTION
Improvement of the REST documentation, putting it on par with SOAP. For sure we will need to improve the documentation even further once we drop SOAP.