### PR TITLE
Add callback URL type to REST client

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
@@ -17,6 +17,7 @@
  */
 package com.wultra.security.powerauth.client;
 
+import com.wultra.security.powerauth.client.model.enumeration.CallbackUrlType;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.*;
@@ -788,7 +789,7 @@ public interface PowerAuthClient {
      * @return Information about new callback URL object.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, String type, String callbackUrl, List<String> attributes) throws PowerAuthClientException;
+    CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, CallbackUrlType type, String callbackUrl, List<String> attributes) throws PowerAuthClientException;
 
     /**
      * Update a callback URL with given request object.

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
@@ -782,12 +782,13 @@ public interface PowerAuthClient {
      *
      * @param applicationId Application ID.
      * @param name          Callback URL display name.
+     * @param type          Callback type.
      * @param callbackUrl   Callback URL value.
      * @param attributes    Attributes to send in the callback data.
      * @return Information about new callback URL object.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, String callbackUrl, List<String> attributes) throws PowerAuthClientException;
+    CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, String type, String callbackUrl, List<String> attributes) throws PowerAuthClientException;
 
     /**
      * Update a callback URL with given request object.
@@ -1336,7 +1337,7 @@ public interface PowerAuthClient {
     /**
      * Get operation template list.
      * @return Operation template list.
-     * @throws PowerAuthClientException
+     * @throws PowerAuthClientException In case REST API call fails.
      */
     OperationTemplateListResponse operationTemplateList() throws PowerAuthClientException;
 

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/enumeration/CallbackUrlType.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/enumeration/CallbackUrlType.java
@@ -1,0 +1,42 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2021 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.client.model.enumeration;
+
+/**
+ * Enumeration for callback URL type.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public enum CallbackUrlType {
+
+    ACTIVATION_STATUS_CHANGE("ACTIVATION_STATUS_CHANGE"),
+    OPERATION_STATUS_CHANGE("OPERATION_STATUS_CHANGE");
+
+    private final String value;
+
+    CallbackUrlType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+}

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
@@ -24,6 +24,7 @@ import com.wultra.core.rest.client.base.DefaultRestClient;
 import com.wultra.core.rest.client.base.RestClient;
 import com.wultra.core.rest.client.base.RestClientException;
 import com.wultra.security.powerauth.client.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.enumeration.CallbackUrlType;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.error.PowerAuthError;
 import com.wultra.security.powerauth.client.model.error.PowerAuthErrorRecovery;
@@ -691,11 +692,11 @@ public class PowerAuthRestClient implements PowerAuthClient {
     }
 
     @Override
-    public CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, String type, String callbackUrl, List<String> attributes) throws PowerAuthClientException {
+    public CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, CallbackUrlType type, String callbackUrl, List<String> attributes) throws PowerAuthClientException {
         CreateCallbackUrlRequest request = new CreateCallbackUrlRequest();
         request.setApplicationId(applicationId);
         request.setName(name);
-        request.setType(type);
+        request.setType(type.toString());
         request.setCallbackUrl(callbackUrl);
         if (attributes != null) {
             request.getAttributes().addAll(attributes);

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
@@ -691,10 +691,11 @@ public class PowerAuthRestClient implements PowerAuthClient {
     }
 
     @Override
-    public CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, String callbackUrl, List<String> attributes) throws PowerAuthClientException {
+    public CreateCallbackUrlResponse createCallbackUrl(Long applicationId, String name, String type, String callbackUrl, List<String> attributes) throws PowerAuthClientException {
         CreateCallbackUrlRequest request = new CreateCallbackUrlRequest();
         request.setApplicationId(applicationId);
         request.setName(name);
+        request.setType(type);
         request.setCallbackUrl(callbackUrl);
         if (attributes != null) {
             request.getAttributes().addAll(attributes);


### PR DESCRIPTION
The missing URL type was causing an exception on server when running tests.