### PR TITLE
Fix scheduling for PowerAuth auditing

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthAuditConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthAuditConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.server.configuration;
+
+import com.wultra.core.audit.base.Audit;
+import com.wultra.core.audit.base.AuditFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = {"com.wultra.core.audit.base"})
+public class PowerAuthAuditConfiguration {
+
+    private final AuditFactory auditFactory;
+
+    /**
+     * Configuration constructor.
+     * @param auditFactory Audit factory.
+     */
+    @Autowired
+    public PowerAuthAuditConfiguration(AuditFactory auditFactory) {
+        this.auditFactory = auditFactory;
+    }
+
+    /**
+     * Prepare audit interface.
+     * @return Audit interface.
+     */
+    @Bean
+    public Audit audit() {
+        return auditFactory.getAudit();
+    }
+
+}

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthAuditConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthAuditConfiguration.java
@@ -24,6 +24,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Configuration of auditing for PowerAuth.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
 @Configuration
 @ComponentScan(basePackages = {"com.wultra.core.audit.base"})
 public class PowerAuthAuditConfiguration {

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/WebServiceConfig.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/WebServiceConfig.java
@@ -18,8 +18,6 @@
 
 package io.getlime.security.powerauth.app.server.configuration;
 
-import com.wultra.core.audit.base.Audit;
-import com.wultra.core.audit.base.AuditFactory;
 import io.getlime.security.powerauth.app.server.service.exceptions.ActivationRecoveryException;
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import io.getlime.security.powerauth.app.server.service.exceptions.SoapFaultExceptionResolver;
@@ -28,7 +26,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -56,14 +53,11 @@ import java.util.Properties;
  */
 @EnableWs
 @Configuration
-@ComponentScan(basePackages = {"com.wultra.core.audit.base"})
 public class WebServiceConfig extends WsConfigurerAdapter {
 
     private final UserDetailsService userDetailsService;
 
     private PowerAuthServiceConfiguration configuration;
-
-    private final AuditFactory auditFactory;
 
     /**
      * Setter for configuration injection.
@@ -77,21 +71,10 @@ public class WebServiceConfig extends WsConfigurerAdapter {
     /**
      * Constructor that accepts an instance of UserDetailsService for autowiring.
      * @param userDetailsService UserDetailsService instance.
-     * @param auditFactory Audit factory.
      */
     @Autowired
-    public WebServiceConfig(@Qualifier("integrationUserDetailsService") UserDetailsService userDetailsService, AuditFactory auditFactory) {
+    public WebServiceConfig(@Qualifier("integrationUserDetailsService") UserDetailsService userDetailsService) {
         this.userDetailsService = userDetailsService;
-        this.auditFactory = auditFactory;
-    }
-
-    /**
-     * Bean instance of audit class produced using a factory.
-     * @return Audit instance.
-     */
-    @Bean
-    public Audit audit() {
-        return auditFactory.getAudit();
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
@@ -74,7 +74,6 @@ public class AuditingServiceBehavior {
      */
     public void log(AuditLevel level, String message, AuditDetail auditDetail,  Object... args) {
         audit.log(message, level, auditDetail, args);
-        audit.flush();
     }
 
     /**
@@ -85,7 +84,6 @@ public class AuditingServiceBehavior {
      */
     public void log(AuditLevel level, String message, Object... args) {
         audit.log(message, level, args);
-        audit.flush();
     }
 
     /**


### PR DESCRIPTION
The problem was that the configuration was done in `WebServiceConfig extends WsConfigurerAdapter` which caused following issue:

```
Bean 'databaseAuditWriter' of type [com.wultra.core.audit.base.database.DatabaseAuditWriter] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
```

Due to this issue the task was not scheduled. Moving configuration to a new configuration class solves the issue.
