### PR TITLE
Allow custom HTTP headers in REST client, log correlation ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
         <!-- PowerAuth Dependencies -->
         <powerauth-java-crypto.version>1.2.0</powerauth-java-crypto.version>
-        <powerauth-rest-base.version>1.4.1</powerauth-rest-base.version>
+        <powerauth-rest-base.version>1.5.0-SNAPSHOT</powerauth-rest-base.version>
         <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
 
         <!-- Java 11 Dependencies -->

--- a/powerauth-client-model/pom.xml
+++ b/powerauth-client-model/pom.xml
@@ -53,6 +53,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
@@ -27,6 +27,7 @@ import com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyReque
 import com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyResponse;
 import com.wultra.security.powerauth.client.v3.*;
 import io.getlime.core.rest.model.base.response.Response;
+import org.springframework.util.MultiValueMap;
 
 import java.util.Date;
 import java.util.List;
@@ -45,7 +46,7 @@ public interface PowerAuthClient {
      * @return {@link GetSystemStatusResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetSystemStatusResponse getSystemStatus(GetSystemStatusRequest request) throws PowerAuthClientException;
+    GetSystemStatusResponse getSystemStatus(GetSystemStatusRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the getSystemStatus method of the PowerAuth 3.0 Server interface.
@@ -62,7 +63,7 @@ public interface PowerAuthClient {
      * @return {@link GetSystemStatusResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetErrorCodeListResponse getErrorList(GetErrorCodeListRequest request) throws PowerAuthClientException;
+    GetErrorCodeListResponse getErrorList(GetErrorCodeListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the getSystemStatus method of the PowerAuth 3.0 Server interface.
@@ -80,7 +81,7 @@ public interface PowerAuthClient {
      * @return {@link InitActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    InitActivationResponse initActivation(InitActivationRequest request) throws PowerAuthClientException;
+    InitActivationResponse initActivation(InitActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the initActivation method of the PowerAuth 3.0 Server interface.
@@ -138,7 +139,7 @@ public interface PowerAuthClient {
      * @return {@link PrepareActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    PrepareActivationResponse prepareActivation(PrepareActivationRequest request) throws PowerAuthClientException;
+    PrepareActivationResponse prepareActivation(PrepareActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the prepareActivation method of the PowerAuth 3.0 Server interface.
@@ -162,7 +163,7 @@ public interface PowerAuthClient {
      * @return Create activation response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateActivationResponse createActivation(CreateActivationRequest request) throws PowerAuthClientException;
+    CreateActivationResponse createActivation(CreateActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the createActivation method of the PowerAuth 3.0 Server interface.
@@ -201,7 +202,7 @@ public interface PowerAuthClient {
      * @return {@link UpdateActivationOtpResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UpdateActivationOtpResponse updateActivationOtp(UpdateActivationOtpRequest request) throws PowerAuthClientException;
+    UpdateActivationOtpResponse updateActivationOtp(UpdateActivationOtpRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the commitActivation method of the PowerAuth 3.0 Server interface.
@@ -210,7 +211,7 @@ public interface PowerAuthClient {
      * @return {@link CommitActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CommitActivationResponse commitActivation(CommitActivationRequest request) throws PowerAuthClientException;
+    CommitActivationResponse commitActivation(CommitActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the commitActivation method of the PowerAuth 3.0 Server interface.
@@ -240,7 +241,7 @@ public interface PowerAuthClient {
      * @return {@link GetActivationStatusResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request) throws PowerAuthClientException;
+    GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the getActivationStatus method of the PowerAuth 3.0 Server interface. This method should be used only
@@ -273,7 +274,7 @@ public interface PowerAuthClient {
      * @return {@link RemoveActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RemoveActivationResponse removeActivation(RemoveActivationRequest request) throws PowerAuthClientException;
+    RemoveActivationResponse removeActivation(RemoveActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the removeActivation method of the PowerAuth 3.0 Server interface.
@@ -303,7 +304,7 @@ public interface PowerAuthClient {
      * @return {@link GetActivationListForUserResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request) throws PowerAuthClientException;
+    GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the getActivationListForUser method of the PowerAuth 3.0 Server interface.
@@ -321,7 +322,7 @@ public interface PowerAuthClient {
      * @return {@link LookupActivationsResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    LookupActivationsResponse lookupActivations(LookupActivationsRequest request) throws PowerAuthClientException;
+    LookupActivationsResponse lookupActivations(LookupActivationsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the lookupActivations method of the PowerAuth 3.0 Server interface.
@@ -344,7 +345,7 @@ public interface PowerAuthClient {
      * @return {@link UpdateStatusForActivationsResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UpdateStatusForActivationsResponse updateStatusForActivations(UpdateStatusForActivationsRequest request) throws PowerAuthClientException;
+    UpdateStatusForActivationsResponse updateStatusForActivations(UpdateStatusForActivationsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the updateStatusForActivations method of the PowerAuth 3.0 Server interface.
@@ -363,7 +364,7 @@ public interface PowerAuthClient {
      * @return {@link VerifySignatureResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    VerifySignatureResponse verifySignature(VerifySignatureRequest request) throws PowerAuthClientException;
+    VerifySignatureResponse verifySignature(VerifySignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the verifySignature method of the PowerAuth 3.0 Server interface.
@@ -387,7 +388,7 @@ public interface PowerAuthClient {
      * @return {@link CreatePersonalizedOfflineSignaturePayloadResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws PowerAuthClientException;
+    CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the createPersonalizedOfflineSignaturePayload method of the PowerAuth 3.0 Server interface.
@@ -406,7 +407,7 @@ public interface PowerAuthClient {
      * @return {@link CreateNonPersonalizedOfflineSignaturePayloadResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws PowerAuthClientException;
+    CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the createNonPersonalizedOfflineSignaturePayload method of the PowerAuth 3.0 Server interface.
@@ -425,7 +426,7 @@ public interface PowerAuthClient {
      * @return {@link VerifyOfflineSignatureResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request) throws PowerAuthClientException;
+    VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Verify offline signature by calling verifyOfflineSignature method of the PowerAuth 3.0 Server interface.
@@ -446,7 +447,7 @@ public interface PowerAuthClient {
      * @return {@link VaultUnlockResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    VaultUnlockResponse unlockVault(VaultUnlockRequest request) throws PowerAuthClientException;
+    VaultUnlockResponse unlockVault(VaultUnlockRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the vaultUnlock method of the PowerAuth 3.0 Server interface.
@@ -475,7 +476,7 @@ public interface PowerAuthClient {
      * @return {@link VerifyECDSASignatureResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request) throws PowerAuthClientException;
+    VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the verifyECDSASignature method of the PowerAuth 3.0 Server interface.
@@ -495,7 +496,7 @@ public interface PowerAuthClient {
      * @return {@link SignatureAuditResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request) throws PowerAuthClientException;
+    SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the verifySignature method of the PowerAuth 3.0 Server interface and get
@@ -529,7 +530,7 @@ public interface PowerAuthClient {
      * @return {@link ActivationHistoryResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request) throws PowerAuthClientException;
+    ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the getActivationHistory method of the PowerAuth 3.0 Server interface.
@@ -549,7 +550,7 @@ public interface PowerAuthClient {
      * @return {@link BlockActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    BlockActivationResponse blockActivation(BlockActivationRequest request) throws PowerAuthClientException;
+    BlockActivationResponse blockActivation(BlockActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the blockActivation method of the PowerAuth 3.0 Server interface.
@@ -569,7 +570,7 @@ public interface PowerAuthClient {
      * @return {@link UnblockActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UnblockActivationResponse unblockActivation(UnblockActivationRequest request) throws PowerAuthClientException;
+    UnblockActivationResponse unblockActivation(UnblockActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the unblockActivation method of the PowerAuth 3.0 Server interface.
@@ -588,7 +589,7 @@ public interface PowerAuthClient {
      * @return {@link GetApplicationListResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetApplicationListResponse getApplicationList(GetApplicationListRequest request) throws PowerAuthClientException;
+    GetApplicationListResponse getApplicationList(GetApplicationListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get the list of all applications that are registered in PowerAuth Server.
@@ -605,7 +606,7 @@ public interface PowerAuthClient {
      * @return {@link GetApplicationDetailResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetApplicationDetailResponse getApplicationDetail(GetApplicationDetailRequest request) throws PowerAuthClientException;
+    GetApplicationDetailResponse getApplicationDetail(GetApplicationDetailRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get the detail of an application with given ID, including the version list.
@@ -632,7 +633,7 @@ public interface PowerAuthClient {
      * @return {@link LookupApplicationByAppKeyResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request) throws PowerAuthClientException;
+    LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Lookup an application by application key.
@@ -650,7 +651,7 @@ public interface PowerAuthClient {
      * @return {@link CreateApplicationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateApplicationResponse createApplication(CreateApplicationRequest request) throws PowerAuthClientException;
+    CreateApplicationResponse createApplication(CreateApplicationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create a new application with given name.
@@ -668,7 +669,7 @@ public interface PowerAuthClient {
      * @return {@link CreateApplicationVersionResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request) throws PowerAuthClientException;
+    CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create a version with a given name for an application with given ID.
@@ -687,7 +688,7 @@ public interface PowerAuthClient {
      * @return {@link UnsupportApplicationVersionResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UnsupportApplicationVersionResponse unsupportApplicationVersion(UnsupportApplicationVersionRequest request) throws PowerAuthClientException;
+    UnsupportApplicationVersionResponse unsupportApplicationVersion(UnsupportApplicationVersionRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Cancel the support for a given application version.
@@ -705,7 +706,7 @@ public interface PowerAuthClient {
      * @return {@link SupportApplicationVersionResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    SupportApplicationVersionResponse supportApplicationVersion(SupportApplicationVersionRequest request) throws PowerAuthClientException;
+    SupportApplicationVersionResponse supportApplicationVersion(SupportApplicationVersionRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Renew the support for a given application version.
@@ -723,7 +724,7 @@ public interface PowerAuthClient {
      * @return New integration information.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateIntegrationResponse createIntegration(CreateIntegrationRequest request) throws PowerAuthClientException;
+    CreateIntegrationResponse createIntegration(CreateIntegrationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create a new integration with given name.
@@ -741,7 +742,7 @@ public interface PowerAuthClient {
      * @return List of integrations.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetIntegrationListResponse getIntegrationList(GetIntegrationListRequest request) throws PowerAuthClientException;
+    GetIntegrationListResponse getIntegrationList(GetIntegrationListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get the list of integrations.
@@ -758,7 +759,7 @@ public interface PowerAuthClient {
      * @return Removal status.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RemoveIntegrationResponse removeIntegration(RemoveIntegrationRequest request) throws PowerAuthClientException;
+    RemoveIntegrationResponse removeIntegration(RemoveIntegrationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Remove integration with given ID.
@@ -776,7 +777,7 @@ public interface PowerAuthClient {
      * @return Information about new callback URL object.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request) throws PowerAuthClientException;
+    CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create a new callback URL with given parameters.
@@ -799,7 +800,7 @@ public interface PowerAuthClient {
      * @return Information about new callback URL object.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UpdateCallbackUrlResponse updateCallbackUrl(UpdateCallbackUrlRequest request) throws PowerAuthClientException;
+    UpdateCallbackUrlResponse updateCallbackUrl(UpdateCallbackUrlRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Update a callback URL with given parameters.
@@ -822,7 +823,7 @@ public interface PowerAuthClient {
      * @return Response with the list of all callback URLs for given application.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetCallbackUrlListResponse getCallbackUrlList(GetCallbackUrlListRequest request) throws PowerAuthClientException;
+    GetCallbackUrlListResponse getCallbackUrlList(GetCallbackUrlListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get the list of callback URL objects.
@@ -840,7 +841,7 @@ public interface PowerAuthClient {
      * @return Information about removal status.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request) throws PowerAuthClientException;
+    RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Remove callback URL.
@@ -858,7 +859,7 @@ public interface PowerAuthClient {
      * @return Response with created token.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateTokenResponse createToken(CreateTokenRequest request) throws PowerAuthClientException;
+    CreateTokenResponse createToken(CreateTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create a new token for basic token-based authentication.
@@ -883,7 +884,7 @@ public interface PowerAuthClient {
      * @return Response with the credentials validation status.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    ValidateTokenResponse validateToken(ValidateTokenRequest request) throws PowerAuthClientException;
+    ValidateTokenResponse validateToken(ValidateTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Validate credentials used for basic token-based authentication.
@@ -904,7 +905,7 @@ public interface PowerAuthClient {
      * @return Response token removal result.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RemoveTokenResponse removeToken(RemoveTokenRequest request) throws PowerAuthClientException;
+    RemoveTokenResponse removeToken(RemoveTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Remove token with given token ID.
@@ -923,7 +924,7 @@ public interface PowerAuthClient {
      * @return ECIES decryptor parameters.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws PowerAuthClientException;
+    GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get ECIES decryptor parameters.
@@ -943,7 +944,7 @@ public interface PowerAuthClient {
      * @return Start upgrade response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws PowerAuthClientException;
+    StartUpgradeResponse startUpgrade(StartUpgradeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Start upgrade of activations to version 3.
@@ -967,7 +968,7 @@ public interface PowerAuthClient {
      * @return Commit upgrade response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request) throws PowerAuthClientException;
+    CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Commit upgrade of activations to version 3.
@@ -986,7 +987,7 @@ public interface PowerAuthClient {
      * @return Create recovery code response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    CreateRecoveryCodeResponse createRecoveryCode(CreateRecoveryCodeRequest request) throws PowerAuthClientException;
+    CreateRecoveryCodeResponse createRecoveryCode(CreateRecoveryCodeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create recovery code for user.
@@ -1006,7 +1007,7 @@ public interface PowerAuthClient {
      * @return Confirm recovery code response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    ConfirmRecoveryCodeResponse confirmRecoveryCode(ConfirmRecoveryCodeRequest request) throws PowerAuthClientException;
+    ConfirmRecoveryCodeResponse confirmRecoveryCode(ConfirmRecoveryCodeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Confirm recovery code.
@@ -1030,7 +1031,7 @@ public interface PowerAuthClient {
      * @return Lookup recovery codes response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    LookupRecoveryCodesResponse lookupRecoveryCodes(LookupRecoveryCodesRequest request) throws PowerAuthClientException;
+    LookupRecoveryCodesResponse lookupRecoveryCodes(LookupRecoveryCodesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Lookup recovery codes.
@@ -1053,7 +1054,7 @@ public interface PowerAuthClient {
      * @return Revoke recovery codes response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RevokeRecoveryCodesResponse revokeRecoveryCodes(RevokeRecoveryCodesRequest request) throws PowerAuthClientException;
+    RevokeRecoveryCodesResponse revokeRecoveryCodes(RevokeRecoveryCodesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Revoke recovery codes.
@@ -1071,7 +1072,7 @@ public interface PowerAuthClient {
      * @return Create activation using recovery code response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RecoveryCodeActivationResponse createActivationUsingRecoveryCode(RecoveryCodeActivationRequest request) throws PowerAuthClientException;
+    RecoveryCodeActivationResponse createActivationUsingRecoveryCode(RecoveryCodeActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create activation using recovery code.
@@ -1097,7 +1098,7 @@ public interface PowerAuthClient {
      * @return Get recovery configuration response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    GetRecoveryConfigResponse getRecoveryConfig(GetRecoveryConfigRequest request) throws PowerAuthClientException;
+    GetRecoveryConfigResponse getRecoveryConfig(GetRecoveryConfigRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get recovery configuration.
@@ -1115,7 +1116,7 @@ public interface PowerAuthClient {
      * @return Update recovery configuration response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UpdateRecoveryConfigResponse updateRecoveryConfig(UpdateRecoveryConfigRequest request) throws PowerAuthClientException;
+    UpdateRecoveryConfigResponse updateRecoveryConfig(UpdateRecoveryConfigRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Update recovery configuration.
@@ -1137,7 +1138,7 @@ public interface PowerAuthClient {
      * @return List activation flags response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    ListActivationFlagsResponse listActivationFlags(ListActivationFlagsRequest request) throws PowerAuthClientException;
+    ListActivationFlagsResponse listActivationFlags(ListActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * List activation flags.
@@ -1155,7 +1156,7 @@ public interface PowerAuthClient {
      * @return Add activation flags response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    AddActivationFlagsResponse addActivationFlags(AddActivationFlagsRequest request) throws PowerAuthClientException;
+    AddActivationFlagsResponse addActivationFlags(AddActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Add activation flags.
@@ -1174,7 +1175,7 @@ public interface PowerAuthClient {
      * @return Update activation flags response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UpdateActivationFlagsResponse updateActivationFlags(UpdateActivationFlagsRequest request) throws PowerAuthClientException;
+    UpdateActivationFlagsResponse updateActivationFlags(UpdateActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Update activation flags.
@@ -1193,7 +1194,7 @@ public interface PowerAuthClient {
      * @return Remove activation flags response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RemoveActivationFlagsResponse removeActivationFlags(RemoveActivationFlagsRequest request) throws PowerAuthClientException;
+    RemoveActivationFlagsResponse removeActivationFlags(RemoveActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Remove activation flags.
@@ -1211,7 +1212,7 @@ public interface PowerAuthClient {
      * @return List application roles response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    ListApplicationRolesResponse listApplicationRoles(ListApplicationRolesRequest request) throws PowerAuthClientException;
+    ListApplicationRolesResponse listApplicationRoles(ListApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * List application roles.
@@ -1227,7 +1228,7 @@ public interface PowerAuthClient {
      * @return Add application roles response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    AddApplicationRolesResponse addApplicationRoles(AddApplicationRolesRequest request) throws PowerAuthClientException;
+    AddApplicationRolesResponse addApplicationRoles(AddApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Add application roles.
@@ -1244,7 +1245,7 @@ public interface PowerAuthClient {
      * @return Update application roles response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    UpdateApplicationRolesResponse updateApplicationRoles(UpdateApplicationRolesRequest request) throws PowerAuthClientException;
+    UpdateApplicationRolesResponse updateApplicationRoles(UpdateApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Update application roles.
@@ -1261,7 +1262,7 @@ public interface PowerAuthClient {
      * @return Remove application roles response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    RemoveApplicationRolesResponse removeApplicationRoles(RemoveApplicationRolesRequest request) throws PowerAuthClientException;
+    RemoveApplicationRolesResponse removeApplicationRoles(RemoveApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Remove application roles.
@@ -1278,7 +1279,7 @@ public interface PowerAuthClient {
      * @return Create operation response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationDetailResponse createOperation(OperationCreateRequest request) throws PowerAuthClientException;
+    OperationDetailResponse createOperation(OperationCreateRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get operation detail.
@@ -1286,7 +1287,7 @@ public interface PowerAuthClient {
      * @return Operation detail response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationDetailResponse operationDetail(OperationDetailRequest request) throws PowerAuthClientException;
+    OperationDetailResponse operationDetail(OperationDetailRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get list with all operations for provided user.
@@ -1294,7 +1295,7 @@ public interface PowerAuthClient {
      * @return Get operation list response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationListResponse operationList(OperationListForUserRequest request) throws PowerAuthClientException;
+    OperationListResponse operationList(OperationListForUserRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get pending operation list.
@@ -1302,7 +1303,7 @@ public interface PowerAuthClient {
      * @return Get pending operation list response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationListResponse operationPendingList(OperationListForUserRequest request) throws PowerAuthClientException;
+    OperationListResponse operationPendingList(OperationListForUserRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Cancel operation.
@@ -1310,7 +1311,7 @@ public interface PowerAuthClient {
      * @return Cancel operation response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationDetailResponse operationCancel(OperationCancelRequest request) throws PowerAuthClientException;
+    OperationDetailResponse operationCancel(OperationCancelRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Approve operation.
@@ -1318,7 +1319,7 @@ public interface PowerAuthClient {
      * @return Approve operation response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationUserActionResponse operationApprove(OperationApproveRequest request) throws PowerAuthClientException;
+    OperationUserActionResponse operationApprove(OperationApproveRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Simulate approval failure. Useful when you need to enforce decrement of a counter,
@@ -1327,7 +1328,7 @@ public interface PowerAuthClient {
      * @return Failed approval operatin request.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationUserActionResponse failApprovalOperation(OperationFailApprovalRequest request) throws PowerAuthClientException;
+    OperationUserActionResponse failApprovalOperation(OperationFailApprovalRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Reject operation.
@@ -1335,7 +1336,7 @@ public interface PowerAuthClient {
      * @return Reject operation response.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationUserActionResponse operationReject(OperationRejectRequest request) throws PowerAuthClientException;
+    OperationUserActionResponse operationReject(OperationRejectRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get operation template list.
@@ -1350,7 +1351,7 @@ public interface PowerAuthClient {
      * @return Operation template detail.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationTemplateDetailResponse operationTemplateDetail(OperationTemplateDetailRequest request) throws PowerAuthClientException;
+    OperationTemplateDetailResponse operationTemplateDetail(OperationTemplateDetailRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Create a new operation template.
@@ -1358,7 +1359,7 @@ public interface PowerAuthClient {
      * @return Operation template detail.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationTemplateDetailResponse createOperationTemplate(OperationTemplateCreateRequest request) throws PowerAuthClientException;
+    OperationTemplateDetailResponse createOperationTemplate(OperationTemplateCreateRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Update an operation template.
@@ -1366,7 +1367,7 @@ public interface PowerAuthClient {
      * @return Operation template detail.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    OperationTemplateDetailResponse updateOperationTemplate(OperationTemplateUpdateRequest request) throws PowerAuthClientException;
+    OperationTemplateDetailResponse updateOperationTemplate(OperationTemplateUpdateRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Remove operation template.
@@ -1374,7 +1375,7 @@ public interface PowerAuthClient {
      * @return Plain response object.
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    Response removeOperationTemplate(OperationTemplateDeleteRequest request) throws PowerAuthClientException;
+    Response removeOperationTemplate(OperationTemplateDeleteRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Get the PowerAuth version 2 client (legacy).
@@ -1390,7 +1391,7 @@ public interface PowerAuthClient {
          * @return {@link com.wultra.security.powerauth.client.v2.PrepareActivationResponse}
          * @throws PowerAuthClientException In case REST API call fails.
          */
-        com.wultra.security.powerauth.client.v2.PrepareActivationResponse prepareActivation(com.wultra.security.powerauth.client.v2.PrepareActivationRequest request) throws PowerAuthClientException;
+        com.wultra.security.powerauth.client.v2.PrepareActivationResponse prepareActivation(com.wultra.security.powerauth.client.v2.PrepareActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
         /**
          * Call the prepareActivation method of the PowerAuth 2.0 Server interface.
@@ -1412,7 +1413,7 @@ public interface PowerAuthClient {
          * @return Create activation response.
          * @throws PowerAuthClientException In case REST API call fails.
          */
-        com.wultra.security.powerauth.client.v2.CreateActivationResponse createActivation(com.wultra.security.powerauth.client.v2.CreateActivationRequest request) throws PowerAuthClientException;
+        com.wultra.security.powerauth.client.v2.CreateActivationResponse createActivation(com.wultra.security.powerauth.client.v2.CreateActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
         /**
          * Call the createActivation method of the PowerAuth 2.0 Server interface.
@@ -1455,7 +1456,7 @@ public interface PowerAuthClient {
          * @return {@link com.wultra.security.powerauth.client.v2.VaultUnlockResponse}
          * @throws PowerAuthClientException In case REST API call fails.
          */
-        com.wultra.security.powerauth.client.v2.VaultUnlockResponse unlockVault(com.wultra.security.powerauth.client.v2.VaultUnlockRequest request) throws PowerAuthClientException;
+        com.wultra.security.powerauth.client.v2.VaultUnlockResponse unlockVault(com.wultra.security.powerauth.client.v2.VaultUnlockRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
         /**
          * Call the vaultUnlock method of the PowerAuth 2.0 Server interface.
@@ -1476,7 +1477,7 @@ public interface PowerAuthClient {
          * @return {@link GetPersonalizedEncryptionKeyResponse}
          * @throws PowerAuthClientException In case REST API call fails.
          */
-        GetPersonalizedEncryptionKeyResponse generatePersonalizedE2EEncryptionKey(GetPersonalizedEncryptionKeyRequest request) throws PowerAuthClientException;
+        GetPersonalizedEncryptionKeyResponse generatePersonalizedE2EEncryptionKey(GetPersonalizedEncryptionKeyRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
         /**
          * Call the generatePersonalizedE2EEncryptionKey method of the PowerAuth 2.0 Server interface and get
@@ -1493,7 +1494,7 @@ public interface PowerAuthClient {
          * @return {@link GetNonPersonalizedEncryptionKeyResponse}
          * @throws PowerAuthClientException In case REST API call fails.
          */
-        GetNonPersonalizedEncryptionKeyResponse generateNonPersonalizedE2EEncryptionKey(GetNonPersonalizedEncryptionKeyRequest request) throws PowerAuthClientException;
+        GetNonPersonalizedEncryptionKeyResponse generateNonPersonalizedE2EEncryptionKey(GetNonPersonalizedEncryptionKeyRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
         /**
          * Call the generateNonPersonalizedE2EEncryptionKey method of the PowerAuth 2.0 Server interface and get
@@ -1510,7 +1511,7 @@ public interface PowerAuthClient {
          * @return Response with created token.
          * @throws PowerAuthClientException In case REST API call fails.
          */
-        com.wultra.security.powerauth.client.v2.CreateTokenResponse createToken(com.wultra.security.powerauth.client.v2.CreateTokenRequest request) throws PowerAuthClientException;
+        com.wultra.security.powerauth.client.v2.CreateTokenResponse createToken(com.wultra.security.powerauth.client.v2.CreateTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
         /**
          * Create a new token for basic token-based authentication.

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 )
 public class InterceptorConfiguration implements WebMvcConfigurer {
 
-    @Value("${powerauth.service.correlation-header.name:Correlation-ID}")
+    @Value("${powerauth.service.correlation-header.name:X-Correlation-ID}")
     private String correlationHeaderName;
 
     @Value("${powerauth.service.correlation-header.value.validation-regexp:[a-zA-Z0-9]}")

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2021 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.server.configuration;
+
+import io.getlime.security.powerauth.app.server.interceptor.HttpHeaderInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Configuration of interceptors.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@ConditionalOnProperty(
+        value = "powerauth.service.correlation-header.enabled",
+        havingValue = "true"
+)
+public class InterceptorConfiguration implements WebMvcConfigurer {
+
+    @Value("${powerauth.service.correlation-header.name:Correlation-ID}")
+    private String correlationHeaderName;
+
+    @Value("${powerauth.service.correlation-header.value.validation-regexp:[a-zA-Z0-9]}")
+    private String correlationHeaderValueValidation;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        HandlerInterceptor httpHeaderInterceptor = new HttpHeaderInterceptor(correlationHeaderName, correlationHeaderValueValidation);
+        registry.addInterceptor(httpHeaderInterceptor);
+    }
+}

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
@@ -40,7 +40,7 @@ public class InterceptorConfiguration implements WebMvcConfigurer {
     @Value("${powerauth.service.correlation-header.name:X-Correlation-ID}")
     private String correlationHeaderName;
 
-    @Value("${powerauth.service.correlation-header.value.validation-regexp:[a-zA-Z0-9]}")
+    @Value("${powerauth.service.correlation-header.value.validation-regexp:[a-zA-Z0-9\\-]{8,128}}")
     private String correlationHeaderValueValidation;
 
     @Override

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/InterceptorConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2021 Wultra s.r.o.
+ * Copyright (C) 2022 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -40,12 +40,12 @@ public class InterceptorConfiguration implements WebMvcConfigurer {
     @Value("${powerauth.service.correlation-header.name:X-Correlation-ID}")
     private String correlationHeaderName;
 
-    @Value("${powerauth.service.correlation-header.value.validation-regexp:[a-zA-Z0-9\\-]{8,128}}")
+    @Value("${powerauth.service.correlation-header.value.validation-regexp:[a-zA-Z0-9\\-]{8,1024}}")
     private String correlationHeaderValueValidation;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        HandlerInterceptor httpHeaderInterceptor = new HttpHeaderInterceptor(correlationHeaderName, correlationHeaderValueValidation);
+        final HandlerInterceptor httpHeaderInterceptor = new HttpHeaderInterceptor(correlationHeaderName, correlationHeaderValueValidation);
         registry.addInterceptor(httpHeaderInterceptor);
     }
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/interceptor/HttpHeaderInterceptor.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/interceptor/HttpHeaderInterceptor.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2021 Wultra s.r.o.
+ * Copyright (C) 2022 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -54,7 +54,7 @@ public class HttpHeaderInterceptor implements HandlerInterceptor {
     }
 
     private String getCorrelationId(HttpServletRequest request) {
-        String headerValue = request.getHeader(correlationHeaderName);
+        final String headerValue = request.getHeader(correlationHeaderName);
         if (headerValue == null) {
             logger.debug("Correlation header {} is null", correlationHeaderName);
             return null;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/interceptor/HttpHeaderInterceptor.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/interceptor/HttpHeaderInterceptor.java
@@ -1,0 +1,68 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2021 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.server.interceptor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * HTTP header interceptor for logging of correlation headers using MDC.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class HttpHeaderInterceptor implements HandlerInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpHeaderInterceptor.class);
+
+    private final String correlationHeaderName;
+    private final String correlationHeaderValueValidation;
+
+    public HttpHeaderInterceptor(String correlationHeaderName, String correlationHeaderValueValidation) {
+        this.correlationHeaderName = correlationHeaderName;
+        this.correlationHeaderValueValidation = correlationHeaderValueValidation;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        MDC.put(correlationHeaderName, getCorrelationId(request));
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        MDC.remove(correlationHeaderName);
+    }
+
+    private String getCorrelationId(HttpServletRequest request) {
+        String headerValue = request.getHeader(correlationHeaderName);
+        if (headerValue == null) {
+            logger.debug("Correlation header {} is null", correlationHeaderName);
+            return null;
+        }
+        if (!headerValue.matches(correlationHeaderValueValidation)) {
+            logger.warn("Correlation header {} is invalid: {}", correlationHeaderName, headerValue);
+            return null;
+        }
+        return headerValue;
+    }
+}

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -118,4 +118,4 @@ powerauth.service.correlation-header.enabled=false
 powerauth.service.correlation-header.name=X-Correlation-ID
 powerauth.service.correlation-header.value.validation-regexp=[a-zA-Z0-9\\-]{8,128}
 # For logging correlation HTTP headers enable the pattern and update correlation header name in the pattern
-#logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} [%X{X-Correlation-ID}] %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx
+#logging.pattern.console=%clr(%d{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:%5p}) [%X{X-Correlation-ID}] %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -112,3 +112,10 @@ spring.application.name=powerauth-java-server
 # Configure Spring Cloud Vault Properties
 spring.cloud.vault.enabled=false
 spring.cloud.vault.kv.enabled=true
+
+# Configure Correlation HTTP Header
+powerauth.service.correlation-header.enabled=false
+powerauth.service.correlation-header.name=X-Correlation-ID
+powerauth.service.correlation-header.value.validation-regexp=[a-zA-Z0-9\\-]{8,128}
+# For logging correlation HTTP headers enable the pattern and update correlation header name in the pattern
+#logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} [%X{X-Correlation-ID}] %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -116,6 +116,6 @@ spring.cloud.vault.kv.enabled=true
 # Configure Correlation HTTP Header
 powerauth.service.correlation-header.enabled=false
 powerauth.service.correlation-header.name=X-Correlation-ID
-powerauth.service.correlation-header.value.validation-regexp=[a-zA-Z0-9\\-]{8,128}
+powerauth.service.correlation-header.value.validation-regexp=[a-zA-Z0-9\\-]{8,1024}
 # For logging correlation HTTP headers enable the pattern and update correlation header name in the pattern
 #logging.pattern.console=%clr(%d{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:%5p}) [%X{X-Correlation-ID}] %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
@@ -57,13 +57,10 @@ public class PowerAuthRestClient implements PowerAuthClient {
     private static final Logger logger = LoggerFactory.getLogger(PowerAuthRestClient.class);
 
     private static final String PA_REST_V3_PREFIX = "/v3";
+    private static final MultiValueMap<String, String> EMPTY_MULTI_MAP = new LinkedMultiValueMap<>();
 
     private final RestClient restClient;
-    private final PowerAuthRestClientConfiguration config;
     private final ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    private MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-    private MultiValueMap<String, String> httpHeaders = new LinkedMultiValueMap<>();
 
     /**
      * PowerAuth REST client constructor.
@@ -80,7 +77,6 @@ public class PowerAuthRestClient implements PowerAuthClient {
      * @param baseUrl Base URL of REST endpoints.
      */
     public PowerAuthRestClient(String baseUrl, PowerAuthRestClientConfiguration config) throws PowerAuthClientException {
-        this.config = config;
         DefaultRestClient.Builder builder = DefaultRestClient.builder().baseUrl(baseUrl)
                 .acceptInvalidCertificate(config.getAcceptInvalidSslCertificate())
                 .connectionTimeout(config.getConnectTimeout())
@@ -109,47 +105,19 @@ public class PowerAuthRestClient implements PowerAuthClient {
     }
 
     /**
-     * Set HTTP query parameters.
-     * @param queryParams HTTP query parameters.
-     */
-    public void setQueryParams(MultiValueMap<String, String> queryParams) {
-        this.queryParams = queryParams;
-    }
-
-    /**
-     * Set HTTP headers.
-     * @param httpHeaders HTTP headers.
-     */
-    public void setHttpHeaders(MultiValueMap<String, String> httpHeaders) {
-        this.httpHeaders = httpHeaders;
-    }
-
-    private <T> T callV3RestApi(String path, Object request, Class<T> responseType) throws PowerAuthClientException {
-        T response = callV3RestApi(path, request, queryParams, httpHeaders, responseType);
-        // Reset query parameters and HTTP headers after REST API call, if required
-        if (config.isResetQueryParams()) {
-            queryParams = new LinkedMultiValueMap<>();
-        }
-        if (config.isResetHttpHeaders()) {
-            httpHeaders = new LinkedMultiValueMap<>();
-        }
-        return response;
-    }
-
-    /**
      * Call the PowerAuth v3 API.
      *
      * @param path Path of the endpoint.
      * @param request Request object.
      * @param queryParams HTTP query parameters.
-     * @param headers HTTP headers.
+     * @param httpHeaders HTTP headers.
      * @param responseType Response type.
      * @return Response.
      */
-    private <T> T callV3RestApi(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Class<T> responseType) throws PowerAuthClientException {
+    private <T> T callV3RestApi(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders, Class<T> responseType) throws PowerAuthClientException {
         ObjectRequest<?> objectRequest = new ObjectRequest<>(request);
         try {
-            ObjectResponse<T> objectResponse = restClient.postObject(PA_REST_V3_PREFIX + path, objectRequest, queryParams, headers, responseType);
+            ObjectResponse<T> objectResponse = restClient.postObject(PA_REST_V3_PREFIX + path, objectRequest, queryParams, httpHeaders, responseType);
             return objectResponse.getResponseObject();
         } catch (RestClientException ex) {
             if (ex.getStatusCode() == null) {
@@ -217,31 +185,31 @@ public class PowerAuthRestClient implements PowerAuthClient {
     }
 
     @Override
-    public GetSystemStatusResponse getSystemStatus(GetSystemStatusRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/status", request, GetSystemStatusResponse.class);
+    public GetSystemStatusResponse getSystemStatus(GetSystemStatusRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/status", request, queryParams, httpHeaders, GetSystemStatusResponse.class);
     }
 
     @Override
     public GetSystemStatusResponse getSystemStatus() throws PowerAuthClientException {
         GetSystemStatusRequest request = new GetSystemStatusRequest();
-        return getSystemStatus(request);
+        return getSystemStatus(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetErrorCodeListResponse getErrorList(GetErrorCodeListRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/error/list", request, GetErrorCodeListResponse.class);
+    public GetErrorCodeListResponse getErrorList(GetErrorCodeListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/error/list", request, queryParams, httpHeaders, GetErrorCodeListResponse.class);
     }
 
     @Override
     public GetErrorCodeListResponse getErrorList(String language) throws PowerAuthClientException {
         GetErrorCodeListRequest request = new GetErrorCodeListRequest();
         request.setLanguage(language);
-        return getErrorList(request);
+        return getErrorList(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public InitActivationResponse initActivation(InitActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/init", request, InitActivationResponse.class);
+    public InitActivationResponse initActivation(InitActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/init", request, queryParams, httpHeaders, InitActivationResponse.class);
     }
 
     @Override
@@ -273,12 +241,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         if (timestampActivationExpire != null) {
             request.setTimestampActivationExpire(calendarWithDate(timestampActivationExpire));
         }
-        return this.initActivation(request);
+        return this.initActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public PrepareActivationResponse prepareActivation(PrepareActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/prepare", request, PrepareActivationResponse.class);
+    public PrepareActivationResponse prepareActivation(PrepareActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/prepare", request, queryParams, httpHeaders, PrepareActivationResponse.class);
     }
 
     @Override
@@ -290,12 +258,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
         request.setNonce(nonce);
-        return prepareActivation(request);
+        return prepareActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateActivationResponse createActivation(CreateActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/create", request, CreateActivationResponse.class);
+    public CreateActivationResponse createActivation(CreateActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/create", request, queryParams, httpHeaders, CreateActivationResponse.class);
     }
 
     @Override
@@ -315,7 +283,7 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
         request.setNonce(nonce);
-        return createActivation(request);
+        return createActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
@@ -324,17 +292,17 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setExternalUserId(externalUserId);
         request.setActivationOtp(activationOtp);
-        return updateActivationOtp(request);
+        return updateActivationOtp(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UpdateActivationOtpResponse updateActivationOtp(UpdateActivationOtpRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/otp/update", request, UpdateActivationOtpResponse.class);
+    public UpdateActivationOtpResponse updateActivationOtp(UpdateActivationOtpRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/otp/update", request, queryParams, httpHeaders, UpdateActivationOtpResponse.class);
     }
 
     @Override
-    public CommitActivationResponse commitActivation(CommitActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/commit", request, CommitActivationResponse.class);
+    public CommitActivationResponse commitActivation(CommitActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/commit", request, queryParams, httpHeaders, CommitActivationResponse.class);
     }
 
     @Override
@@ -342,7 +310,7 @@ public class PowerAuthRestClient implements PowerAuthClient {
         CommitActivationRequest request = new CommitActivationRequest();
         request.setActivationId(activationId);
         request.setExternalUserId(externalUserId);
-        return this.commitActivation(request);
+        return this.commitActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
@@ -351,12 +319,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setExternalUserId(externalUserId);
         request.setActivationOtp(activationOtp);
-        return this.commitActivation(request);
+        return this.commitActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/status", request, GetActivationStatusResponse.class);
+    public GetActivationStatusResponse getActivationStatus(GetActivationStatusRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/status", request, queryParams, httpHeaders, GetActivationStatusResponse.class);
     }
 
     @Override
@@ -371,12 +339,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         GetActivationStatusRequest request = new GetActivationStatusRequest();
         request.setActivationId(activationId);
         request.setChallenge(challenge);
-        return this.getActivationStatus(request);
+        return this.getActivationStatus(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public RemoveActivationResponse removeActivation(RemoveActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/remove", request, RemoveActivationResponse.class);
+    public RemoveActivationResponse removeActivation(RemoveActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/remove", request, queryParams, httpHeaders, RemoveActivationResponse.class);
     }
 
     @Override
@@ -390,24 +358,24 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setExternalUserId(externalUserId);
         request.setRevokeRecoveryCodes(revokeRecoveryCodes);
-        return this.removeActivation(request);
+        return this.removeActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/list", request, GetActivationListForUserResponse.class);
+    public GetActivationListForUserResponse getActivationListForUser(GetActivationListForUserRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/list", request, queryParams, httpHeaders, GetActivationListForUserResponse.class);
     }
 
     @Override
     public List<GetActivationListForUserResponse.Activations> getActivationListForUser(String userId) throws PowerAuthClientException {
         GetActivationListForUserRequest request = new GetActivationListForUserRequest();
         request.setUserId(userId);
-        return this.getActivationListForUser(request).getActivations();
+        return this.getActivationListForUser(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getActivations();
     }
 
     @Override
-    public LookupActivationsResponse lookupActivations(LookupActivationsRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/lookup", request, LookupActivationsResponse.class);
+    public LookupActivationsResponse lookupActivations(LookupActivationsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/lookup", request, queryParams, httpHeaders, LookupActivationsResponse.class);
     }
 
     @Override
@@ -429,12 +397,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         if (activationFlags != null) {
             request.getActivationFlags().addAll(activationFlags);
         }
-        return this.lookupActivations(request).getActivations();
+        return this.lookupActivations(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getActivations();
     }
 
     @Override
-    public UpdateStatusForActivationsResponse updateStatusForActivations(UpdateStatusForActivationsRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/status/update", request, UpdateStatusForActivationsResponse.class);
+    public UpdateStatusForActivationsResponse updateStatusForActivations(UpdateStatusForActivationsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/status/update", request, queryParams, httpHeaders, UpdateStatusForActivationsResponse.class);
     }
 
     @Override
@@ -444,12 +412,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         if (activationStatus != null) {
             request.setActivationStatus(activationStatus);
         }
-        return this.updateStatusForActivations(request);
+        return this.updateStatusForActivations(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public VerifySignatureResponse verifySignature(VerifySignatureRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/signature/verify", request, VerifySignatureResponse.class);
+    public VerifySignatureResponse verifySignature(VerifySignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/signature/verify", request, queryParams, httpHeaders, VerifySignatureResponse.class);
     }
 
     @Override
@@ -462,12 +430,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setSignatureType(signatureType);
         request.setSignatureVersion(signatureVersion);
         request.setForcedSignatureVersion(forcedSignatureVersion);
-        return this.verifySignature(request);
+        return this.verifySignature(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/signature/offline/personalized/create", request, CreatePersonalizedOfflineSignaturePayloadResponse.class);
+    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/signature/offline/personalized/create", request, queryParams, httpHeaders, CreatePersonalizedOfflineSignaturePayloadResponse.class);
     }
 
     @Override
@@ -475,12 +443,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         CreatePersonalizedOfflineSignaturePayloadRequest request = new CreatePersonalizedOfflineSignaturePayloadRequest();
         request.setActivationId(activationId);
         request.setData(data);
-        return createPersonalizedOfflineSignaturePayload(request);
+        return createPersonalizedOfflineSignaturePayload(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/signature/offline/non-personalized/create", request, CreateNonPersonalizedOfflineSignaturePayloadResponse.class);
+    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/signature/offline/non-personalized/create", request, queryParams, httpHeaders, CreateNonPersonalizedOfflineSignaturePayloadResponse.class);
     }
 
     @Override
@@ -488,12 +456,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         CreateNonPersonalizedOfflineSignaturePayloadRequest request = new CreateNonPersonalizedOfflineSignaturePayloadRequest();
         request.setApplicationId(applicationId);
         request.setData(data);
-        return createNonPersonalizedOfflineSignaturePayload(request);
+        return createNonPersonalizedOfflineSignaturePayload(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/signature/offline/verify", request, VerifyOfflineSignatureResponse.class);
+    public VerifyOfflineSignatureResponse verifyOfflineSignature(VerifyOfflineSignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/signature/offline/verify", request, queryParams, httpHeaders, VerifyOfflineSignatureResponse.class);
     }
 
     @Override
@@ -503,12 +471,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setData(data);
         request.setSignature(signature);
         request.setAllowBiometry(allowBiometry);
-        return verifyOfflineSignature(request);
+        return verifyOfflineSignature(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public VaultUnlockResponse unlockVault(VaultUnlockRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/vault/unlock", request, VaultUnlockResponse.class);
+    public VaultUnlockResponse unlockVault(VaultUnlockRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/vault/unlock", request, queryParams, httpHeaders, VaultUnlockResponse.class);
     }
 
     @Override
@@ -526,12 +494,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
         request.setNonce(nonce);
-        return unlockVault(request);
+        return unlockVault(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/signature/ecdsa/verify", request, VerifyECDSASignatureResponse.class);
+    public VerifyECDSASignatureResponse verifyECDSASignature(VerifyECDSASignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/signature/ecdsa/verify", request, queryParams, httpHeaders, VerifyECDSASignatureResponse.class);
     }
 
     @Override
@@ -540,12 +508,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setData(data);
         request.setSignature(signature);
-        return this.verifyECDSASignature(request);
+        return this.verifyECDSASignature(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/signature/list", request, SignatureAuditResponse.class);
+    public SignatureAuditResponse getSignatureAuditLog(SignatureAuditRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/signature/list", request, queryParams, httpHeaders, SignatureAuditResponse.class);
     }
 
     @Override
@@ -554,7 +522,7 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setUserId(userId);
         request.setTimestampFrom(calendarWithDate(startingDate));
         request.setTimestampTo(calendarWithDate(endingDate));
-        return this.getSignatureAuditLog(request).getItems();
+        return this.getSignatureAuditLog(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getItems();
     }
 
     @Override
@@ -564,12 +532,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setApplicationId(applicationId);
         request.setTimestampFrom(calendarWithDate(startingDate));
         request.setTimestampTo(calendarWithDate(endingDate));
-        return this.getSignatureAuditLog(request).getItems();
+        return this.getSignatureAuditLog(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getItems();
     }
 
     @Override
-    public ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/history", request, ActivationHistoryResponse.class);
+    public ActivationHistoryResponse getActivationHistory(ActivationHistoryRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/history", request, queryParams, httpHeaders, ActivationHistoryResponse.class);
     }
 
     @Override
@@ -578,12 +546,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setTimestampFrom(calendarWithDate(startingDate));
         request.setTimestampTo(calendarWithDate(endingDate));
-        return this.getActivationHistory(request).getItems();
+        return this.getActivationHistory(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getItems();
     }
 
     @Override
-    public BlockActivationResponse blockActivation(BlockActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/block", request, BlockActivationResponse.class);
+    public BlockActivationResponse blockActivation(BlockActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/block", request, queryParams, httpHeaders, BlockActivationResponse.class);
     }
 
     @Override
@@ -592,12 +560,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setReason(reason);
         request.setExternalUserId(externalUserId);
-        return this.blockActivation(request);
+        return this.blockActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UnblockActivationResponse unblockActivation(UnblockActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/unblock", request, UnblockActivationResponse.class);
+    public UnblockActivationResponse unblockActivation(UnblockActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/unblock", request, queryParams, httpHeaders, UnblockActivationResponse.class);
     }
 
     @Override
@@ -605,65 +573,65 @@ public class PowerAuthRestClient implements PowerAuthClient {
         UnblockActivationRequest request = new UnblockActivationRequest();
         request.setActivationId(activationId);
         request.setExternalUserId(externalUserId);
-        return this.unblockActivation(request);
+        return this.unblockActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetApplicationListResponse getApplicationList(GetApplicationListRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/list", request, GetApplicationListResponse.class);
+    public GetApplicationListResponse getApplicationList(GetApplicationListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/list", request, queryParams, httpHeaders, GetApplicationListResponse.class);
     }
 
     @Override
     public List<GetApplicationListResponse.Applications> getApplicationList() throws PowerAuthClientException {
-        return this.getApplicationList(new GetApplicationListRequest()).getApplications();
+        return this.getApplicationList(new GetApplicationListRequest(), EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getApplications();
     }
 
     @Override
-    public GetApplicationDetailResponse getApplicationDetail(GetApplicationDetailRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/detail", request, GetApplicationDetailResponse.class);
+    public GetApplicationDetailResponse getApplicationDetail(GetApplicationDetailRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/detail", request, queryParams, httpHeaders, GetApplicationDetailResponse.class);
     }
 
     @Override
     public GetApplicationDetailResponse getApplicationDetail(Long applicationId) throws PowerAuthClientException {
         GetApplicationDetailRequest request = new GetApplicationDetailRequest();
         request.setApplicationId(applicationId);
-        return this.getApplicationDetail(request);
+        return this.getApplicationDetail(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
     public GetApplicationDetailResponse getApplicationDetail(String applicationName) throws PowerAuthClientException {
         GetApplicationDetailRequest request = new GetApplicationDetailRequest();
         request.setApplicationName(applicationName);
-        return this.getApplicationDetail(request);
+        return this.getApplicationDetail(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/detail/version", request, LookupApplicationByAppKeyResponse.class);
+    public LookupApplicationByAppKeyResponse lookupApplicationByAppKey(LookupApplicationByAppKeyRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/detail/version", request, queryParams, httpHeaders, LookupApplicationByAppKeyResponse.class);
     }
 
     @Override
     public LookupApplicationByAppKeyResponse lookupApplicationByAppKey(String applicationKey) throws PowerAuthClientException {
         LookupApplicationByAppKeyRequest request = new LookupApplicationByAppKeyRequest();
         request.setApplicationKey(applicationKey);
-        return this.lookupApplicationByAppKey(request);
+        return this.lookupApplicationByAppKey(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateApplicationResponse createApplication(CreateApplicationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/create", request, CreateApplicationResponse.class);
+    public CreateApplicationResponse createApplication(CreateApplicationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/create", request, queryParams, httpHeaders, CreateApplicationResponse.class);
     }
 
     @Override
     public CreateApplicationResponse createApplication(String name) throws PowerAuthClientException {
         CreateApplicationRequest request = new CreateApplicationRequest();
         request.setApplicationName(name);
-        return this.createApplication(request);
+        return this.createApplication(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/version/create", request, CreateApplicationVersionResponse.class);
+    public CreateApplicationVersionResponse createApplicationVersion(CreateApplicationVersionRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/version/create", request, queryParams, httpHeaders, CreateApplicationVersionResponse.class);
     }
 
     @Override
@@ -671,70 +639,70 @@ public class PowerAuthRestClient implements PowerAuthClient {
         CreateApplicationVersionRequest request = new CreateApplicationVersionRequest();
         request.setApplicationId(applicationId);
         request.setApplicationVersionName(versionName);
-        return this.createApplicationVersion(request);
+        return this.createApplicationVersion(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UnsupportApplicationVersionResponse unsupportApplicationVersion(UnsupportApplicationVersionRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/version/unsupport", request, UnsupportApplicationVersionResponse.class);
+    public UnsupportApplicationVersionResponse unsupportApplicationVersion(UnsupportApplicationVersionRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/version/unsupport", request, queryParams, httpHeaders, UnsupportApplicationVersionResponse.class);
     }
 
     @Override
     public UnsupportApplicationVersionResponse unsupportApplicationVersion(Long versionId) throws PowerAuthClientException {
         UnsupportApplicationVersionRequest request = new UnsupportApplicationVersionRequest();
         request.setApplicationVersionId(versionId);
-        return this.unsupportApplicationVersion(request);
+        return this.unsupportApplicationVersion(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public SupportApplicationVersionResponse supportApplicationVersion(SupportApplicationVersionRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/version/support", request, SupportApplicationVersionResponse.class);
+    public SupportApplicationVersionResponse supportApplicationVersion(SupportApplicationVersionRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/version/support", request, queryParams, httpHeaders, SupportApplicationVersionResponse.class);
     }
 
     @Override
     public SupportApplicationVersionResponse supportApplicationVersion(Long versionId) throws PowerAuthClientException {
         SupportApplicationVersionRequest request = new SupportApplicationVersionRequest();
         request.setApplicationVersionId(versionId);
-        return this.supportApplicationVersion(request);
+        return this.supportApplicationVersion(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateIntegrationResponse createIntegration(CreateIntegrationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/integration/create", request, CreateIntegrationResponse.class);
+    public CreateIntegrationResponse createIntegration(CreateIntegrationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/integration/create", request, queryParams, httpHeaders, CreateIntegrationResponse.class);
     }
 
     @Override
     public CreateIntegrationResponse createIntegration(String name) throws PowerAuthClientException {
         CreateIntegrationRequest request = new CreateIntegrationRequest();
         request.setName(name);
-        return this.createIntegration(request);
+        return this.createIntegration(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetIntegrationListResponse getIntegrationList(GetIntegrationListRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/integration/list", request, GetIntegrationListResponse.class);
+    public GetIntegrationListResponse getIntegrationList(GetIntegrationListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/integration/list", request, queryParams, httpHeaders, GetIntegrationListResponse.class);
     }
 
     @Override
     public List<GetIntegrationListResponse.Items> getIntegrationList() throws PowerAuthClientException {
-        return this.getIntegrationList(new GetIntegrationListRequest()).getItems();
+        return this.getIntegrationList(new GetIntegrationListRequest(), EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getItems();
     }
 
     @Override
-    public RemoveIntegrationResponse removeIntegration(RemoveIntegrationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/integration/remove", request, RemoveIntegrationResponse.class);
+    public RemoveIntegrationResponse removeIntegration(RemoveIntegrationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/integration/remove", request, queryParams, httpHeaders, RemoveIntegrationResponse.class);
     }
 
     @Override
     public RemoveIntegrationResponse removeIntegration(String id) throws PowerAuthClientException {
         RemoveIntegrationRequest request = new RemoveIntegrationRequest();
         request.setId(id);
-        return this.removeIntegration(request);
+        return this.removeIntegration(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/callback/create", request, CreateCallbackUrlResponse.class);
+    public CreateCallbackUrlResponse createCallbackUrl(CreateCallbackUrlRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/callback/create", request, queryParams, httpHeaders, CreateCallbackUrlResponse.class);
     }
 
     @Override
@@ -748,12 +716,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.getAttributes().addAll(attributes);
         }
         request.setAuthentication(authentication);
-        return this.createCallbackUrl(request);
+        return this.createCallbackUrl(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UpdateCallbackUrlResponse updateCallbackUrl(UpdateCallbackUrlRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/callback/update", request, UpdateCallbackUrlResponse.class);
+    public UpdateCallbackUrlResponse updateCallbackUrl(UpdateCallbackUrlRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/callback/update", request, queryParams, httpHeaders, UpdateCallbackUrlResponse.class);
     }
 
     @Override
@@ -767,36 +735,36 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.getAttributes().addAll(attributes);
         }
         request.setAuthentication(authentication);
-        return this.updateCallbackUrl(request);
+        return this.updateCallbackUrl(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetCallbackUrlListResponse getCallbackUrlList(GetCallbackUrlListRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/callback/list", request, GetCallbackUrlListResponse.class);
+    public GetCallbackUrlListResponse getCallbackUrlList(GetCallbackUrlListRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/callback/list", request, queryParams, httpHeaders, GetCallbackUrlListResponse.class);
     }
 
     @Override
     public List<GetCallbackUrlListResponse.CallbackUrlList> getCallbackUrlList(Long applicationId) throws PowerAuthClientException {
         GetCallbackUrlListRequest request = new GetCallbackUrlListRequest();
         request.setApplicationId(applicationId);
-        return getCallbackUrlList(request).getCallbackUrlList();
+        return getCallbackUrlList(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP).getCallbackUrlList();
     }
 
     @Override
-    public RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/callback/remove", request, RemoveCallbackUrlResponse.class);
+    public RemoveCallbackUrlResponse removeCallbackUrl(RemoveCallbackUrlRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/callback/remove", request, queryParams, httpHeaders, RemoveCallbackUrlResponse.class);
     }
 
     @Override
     public RemoveCallbackUrlResponse removeCallbackUrl(String callbackUrlId) throws PowerAuthClientException {
         RemoveCallbackUrlRequest request = new RemoveCallbackUrlRequest();
         request.setId(callbackUrlId);
-        return removeCallbackUrl(request);
+        return removeCallbackUrl(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateTokenResponse createToken(CreateTokenRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/token/create", request, CreateTokenResponse.class);
+    public CreateTokenResponse createToken(CreateTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/token/create", request, queryParams, httpHeaders, CreateTokenResponse.class);
     }
 
     @Override
@@ -810,12 +778,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEphemeralPublicKey(ephemeralPublicKey);
         request.setNonce(nonce);
         request.setSignatureType(signatureType);
-        return createToken(request);
+        return createToken(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public ValidateTokenResponse validateToken(ValidateTokenRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/token/validate", request, ValidateTokenResponse.class);
+    public ValidateTokenResponse validateToken(ValidateTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/token/validate", request, queryParams, httpHeaders, ValidateTokenResponse.class);
     }
 
     @Override
@@ -825,12 +793,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setNonce(nonce);
         request.setTimestamp(timestamp);
         request.setTokenDigest(tokenDigest);
-        return validateToken(request);
+        return validateToken(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public RemoveTokenResponse removeToken(RemoveTokenRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/token/remove", request, RemoveTokenResponse.class);
+    public RemoveTokenResponse removeToken(RemoveTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/token/remove", request, queryParams, httpHeaders, RemoveTokenResponse.class);
     }
 
     @Override
@@ -838,12 +806,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         RemoveTokenRequest request = new RemoveTokenRequest();
         request.setTokenId(tokenId);
         request.setActivationId(activationId);
-        return removeToken(request);
+        return removeToken(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/ecies/decryptor", request, GetEciesDecryptorResponse.class);
+    public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/ecies/decryptor", request, queryParams, httpHeaders, GetEciesDecryptorResponse.class);
     }
 
     @Override
@@ -852,12 +820,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setActivationId(activationId);
         request.setApplicationKey(applicationKey);
         request.setEphemeralPublicKey(ephemeralPublicKey);
-        return getEciesDecryptor(request);
+        return getEciesDecryptor(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/upgrade/start", request, StartUpgradeResponse.class);
+    public StartUpgradeResponse startUpgrade(StartUpgradeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/upgrade/start", request, queryParams, httpHeaders, StartUpgradeResponse.class);
     }
 
     @Override
@@ -870,12 +838,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
         request.setNonce(nonce);
-        return startUpgrade(request);
+        return startUpgrade(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/upgrade/commit", request, CommitUpgradeResponse.class);
+    public CommitUpgradeResponse commitUpgrade(CommitUpgradeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/upgrade/commit", request, queryParams, httpHeaders, CommitUpgradeResponse.class);
     }
 
     @Override
@@ -883,12 +851,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         CommitUpgradeRequest request = new CommitUpgradeRequest();
         request.setActivationId(activationId);
         request.setApplicationKey(applicationKey);
-        return commitUpgrade(request);
+        return commitUpgrade(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public CreateRecoveryCodeResponse createRecoveryCode(CreateRecoveryCodeRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/recovery/create", request, CreateRecoveryCodeResponse.class);
+    public CreateRecoveryCodeResponse createRecoveryCode(CreateRecoveryCodeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/recovery/create", request, queryParams, httpHeaders, CreateRecoveryCodeResponse.class);
     }
 
     @Override
@@ -897,12 +865,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setApplicationId(applicationId);
         request.setUserId(userId);
         request.setPukCount(pukCount);
-        return createRecoveryCode(request);
+        return createRecoveryCode(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public ConfirmRecoveryCodeResponse confirmRecoveryCode(ConfirmRecoveryCodeRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/recovery/confirm", request, ConfirmRecoveryCodeResponse.class);
+    public ConfirmRecoveryCodeResponse confirmRecoveryCode(ConfirmRecoveryCodeRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/recovery/confirm", request, queryParams, httpHeaders, ConfirmRecoveryCodeResponse.class);
     }
 
     @Override
@@ -915,12 +883,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
         request.setNonce(nonce);
-        return confirmRecoveryCode(request);
+        return confirmRecoveryCode(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public LookupRecoveryCodesResponse lookupRecoveryCodes(LookupRecoveryCodesRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/recovery/lookup", request, LookupRecoveryCodesResponse.class);
+    public LookupRecoveryCodesResponse lookupRecoveryCodes(LookupRecoveryCodesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/recovery/lookup", request, queryParams, httpHeaders, LookupRecoveryCodesResponse.class);
     }
 
     @Override
@@ -932,24 +900,24 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setApplicationId(applicationId);
         request.setRecoveryCodeStatus(recoveryCodeStatus);
         request.setRecoveryPukStatus(recoveryPukStatus);
-        return lookupRecoveryCodes(request);
+        return lookupRecoveryCodes(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public RevokeRecoveryCodesResponse revokeRecoveryCodes(RevokeRecoveryCodesRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/recovery/revoke", request, RevokeRecoveryCodesResponse.class);
+    public RevokeRecoveryCodesResponse revokeRecoveryCodes(RevokeRecoveryCodesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/recovery/revoke", request, queryParams, httpHeaders, RevokeRecoveryCodesResponse.class);
     }
 
     @Override
     public RevokeRecoveryCodesResponse revokeRecoveryCodes(List<Long> recoveryCodeIds) throws PowerAuthClientException {
         RevokeRecoveryCodesRequest request = new RevokeRecoveryCodesRequest();
         request.getRecoveryCodeIds().addAll(recoveryCodeIds);
-        return revokeRecoveryCodes(request);
+        return revokeRecoveryCodes(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public RecoveryCodeActivationResponse createActivationUsingRecoveryCode(RecoveryCodeActivationRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/recovery/create", request, RecoveryCodeActivationResponse.class);
+    public RecoveryCodeActivationResponse createActivationUsingRecoveryCode(RecoveryCodeActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/recovery/create", request, queryParams, httpHeaders, RecoveryCodeActivationResponse.class);
     }
 
     @Override
@@ -966,24 +934,24 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setEncryptedData(encryptedData);
         request.setMac(mac);
         request.setNonce(nonce);
-        return createActivationUsingRecoveryCode(request);
+        return createActivationUsingRecoveryCode(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public GetRecoveryConfigResponse getRecoveryConfig(GetRecoveryConfigRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/recovery/config/detail", request, GetRecoveryConfigResponse.class);
+    public GetRecoveryConfigResponse getRecoveryConfig(GetRecoveryConfigRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/recovery/config/detail", request, queryParams, httpHeaders, GetRecoveryConfigResponse.class);
     }
 
     @Override
     public GetRecoveryConfigResponse getRecoveryConfig(Long applicationId) throws PowerAuthClientException {
         GetRecoveryConfigRequest request = new GetRecoveryConfigRequest();
         request.setApplicationId(applicationId);
-        return getRecoveryConfig(request);
+        return getRecoveryConfig(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UpdateRecoveryConfigResponse updateRecoveryConfig(UpdateRecoveryConfigRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/recovery/config/update", request, UpdateRecoveryConfigResponse.class);
+    public UpdateRecoveryConfigResponse updateRecoveryConfig(UpdateRecoveryConfigRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/recovery/config/update", request, queryParams, httpHeaders, UpdateRecoveryConfigResponse.class);
     }
 
     @Override
@@ -994,24 +962,24 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setRecoveryPostcardEnabled(recoveryPostcardEnabled);
         request.setAllowMultipleRecoveryCodes(allowMultipleRecoveryCodes);
         request.setRemotePostcardPublicKey(remoteRecoveryPublicKeyBase64);
-        return updateRecoveryConfig(request);
+        return updateRecoveryConfig(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public ListActivationFlagsResponse listActivationFlags(ListActivationFlagsRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/flags/list", request, ListActivationFlagsResponse.class);
+    public ListActivationFlagsResponse listActivationFlags(ListActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/flags/list", request, queryParams, httpHeaders, ListActivationFlagsResponse.class);
     }
 
     @Override
     public ListActivationFlagsResponse listActivationFlags(String activationId) throws PowerAuthClientException {
         ListActivationFlagsRequest request = new ListActivationFlagsRequest();
         request.setActivationId(activationId);
-        return listActivationFlags(request);
+        return listActivationFlags(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public AddActivationFlagsResponse addActivationFlags(AddActivationFlagsRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/flags/create", request, AddActivationFlagsResponse.class);
+    public AddActivationFlagsResponse addActivationFlags(AddActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/flags/create", request, queryParams, httpHeaders, AddActivationFlagsResponse.class);
     }
 
     @Override
@@ -1019,12 +987,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         AddActivationFlagsRequest request = new AddActivationFlagsRequest();
         request.setActivationId(activationId);
         request.getActivationFlags().addAll(activationFlags);
-        return addActivationFlags(request);
+        return addActivationFlags(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UpdateActivationFlagsResponse updateActivationFlags(UpdateActivationFlagsRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/flags/update", request, UpdateActivationFlagsResponse.class);
+    public UpdateActivationFlagsResponse updateActivationFlags(UpdateActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/flags/update", request, queryParams, httpHeaders, UpdateActivationFlagsResponse.class);
     }
 
     @Override
@@ -1032,12 +1000,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         UpdateActivationFlagsRequest request = new UpdateActivationFlagsRequest();
         request.setActivationId(activationId);
         request.getActivationFlags().addAll(activationFlags);
-        return updateActivationFlags(request);
+        return updateActivationFlags(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public RemoveActivationFlagsResponse removeActivationFlags(RemoveActivationFlagsRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/activation/flags/remove", request, RemoveActivationFlagsResponse.class);
+    public RemoveActivationFlagsResponse removeActivationFlags(RemoveActivationFlagsRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/activation/flags/remove", request, queryParams, httpHeaders, RemoveActivationFlagsResponse.class);
     }
 
     @Override
@@ -1045,24 +1013,24 @@ public class PowerAuthRestClient implements PowerAuthClient {
         RemoveActivationFlagsRequest request = new RemoveActivationFlagsRequest();
         request.setActivationId(activationId);
         request.getActivationFlags().addAll(activationFlags);
-        return removeActivationFlags(request);
+        return removeActivationFlags(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public ListApplicationRolesResponse listApplicationRoles(ListApplicationRolesRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/roles/list", request, ListApplicationRolesResponse.class);
+    public ListApplicationRolesResponse listApplicationRoles(ListApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/roles/list", request, queryParams, httpHeaders, ListApplicationRolesResponse.class);
     }
 
     @Override
     public ListApplicationRolesResponse listApplicationRoles(Long applicationId) throws PowerAuthClientException {
         ListApplicationRolesRequest request = new ListApplicationRolesRequest();
         request.setApplicationId(applicationId);
-        return listApplicationRoles(request);
+        return listApplicationRoles(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public AddApplicationRolesResponse addApplicationRoles(AddApplicationRolesRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/roles/create", request, AddApplicationRolesResponse.class);
+    public AddApplicationRolesResponse addApplicationRoles(AddApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/roles/create", request, queryParams, httpHeaders, AddApplicationRolesResponse.class);
     }
 
     @Override
@@ -1070,12 +1038,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         AddApplicationRolesRequest request = new AddApplicationRolesRequest();
         request.setApplicationId(applicationId);
         request.getApplicationRoles().addAll(applicationRoles);
-        return addApplicationRoles(request);
+        return addApplicationRoles(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public UpdateApplicationRolesResponse updateApplicationRoles(UpdateApplicationRolesRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/roles/update", request, UpdateApplicationRolesResponse.class);
+    public UpdateApplicationRolesResponse updateApplicationRoles(UpdateApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/roles/update", request, queryParams, httpHeaders, UpdateApplicationRolesResponse.class);
     }
 
     @Override
@@ -1083,12 +1051,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
         UpdateApplicationRolesRequest request = new UpdateApplicationRolesRequest();
         request.setApplicationId(applicationId);
         request.getApplicationRoles().addAll(applicationRoles);
-        return updateApplicationRoles(request);
+        return updateApplicationRoles(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public RemoveApplicationRolesResponse removeApplicationRoles(RemoveApplicationRolesRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/application/roles/remove", request, RemoveApplicationRolesResponse.class);
+    public RemoveApplicationRolesResponse removeApplicationRoles(RemoveApplicationRolesRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/application/roles/remove", request, queryParams, httpHeaders, RemoveApplicationRolesResponse.class);
     }
 
     @Override
@@ -1096,72 +1064,72 @@ public class PowerAuthRestClient implements PowerAuthClient {
         RemoveApplicationRolesRequest request = new RemoveApplicationRolesRequest();
         request.setApplicationId(applicationId);
         request.getApplicationRoles().addAll(applicationRoles);
-        return removeApplicationRoles(request);
+        return removeApplicationRoles(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
 
     @Override
-    public OperationDetailResponse createOperation(OperationCreateRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/create", request, OperationDetailResponse.class);
+    public OperationDetailResponse createOperation(OperationCreateRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/create", request, queryParams, httpHeaders, OperationDetailResponse.class);
     }
 
     @Override
-    public OperationDetailResponse operationDetail(OperationDetailRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/detail", request, OperationDetailResponse.class);
+    public OperationDetailResponse operationDetail(OperationDetailRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/detail", request, queryParams, httpHeaders, OperationDetailResponse.class);
     }
 
     @Override
-    public OperationListResponse operationList(OperationListForUserRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/list", request, OperationListResponse.class);
+    public OperationListResponse operationList(OperationListForUserRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/list", request, queryParams, httpHeaders, OperationListResponse.class);
     }
 
     @Override
-    public OperationListResponse operationPendingList(OperationListForUserRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/list/pending", request, OperationListResponse.class);
+    public OperationListResponse operationPendingList(OperationListForUserRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/list/pending", request, queryParams, httpHeaders, OperationListResponse.class);
     }
 
     @Override
-    public OperationDetailResponse operationCancel(OperationCancelRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/cancel", request, OperationDetailResponse.class);
+    public OperationDetailResponse operationCancel(OperationCancelRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/cancel", request, queryParams, httpHeaders, OperationDetailResponse.class);
     }
 
     @Override
-    public OperationUserActionResponse operationApprove(OperationApproveRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/approve", request, OperationUserActionResponse.class);
+    public OperationUserActionResponse operationApprove(OperationApproveRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/approve", request, queryParams, httpHeaders, OperationUserActionResponse.class);
     }
 
     @Override
-    public OperationUserActionResponse failApprovalOperation(OperationFailApprovalRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/approve/fail", request, OperationUserActionResponse.class);
+    public OperationUserActionResponse failApprovalOperation(OperationFailApprovalRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/approve/fail", request, queryParams, httpHeaders, OperationUserActionResponse.class);
     }
 
     @Override
-    public OperationUserActionResponse operationReject(OperationRejectRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/reject", request, OperationUserActionResponse.class);
+    public OperationUserActionResponse operationReject(OperationRejectRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/reject", request, queryParams, httpHeaders, OperationUserActionResponse.class);
     }
 
     @Override
     public OperationTemplateListResponse operationTemplateList() throws PowerAuthClientException {
-        return callV3RestApi("/operation/template/list", new Object(), OperationTemplateListResponse.class);
+        return callV3RestApi("/operation/template/list", new Object(), EMPTY_MULTI_MAP, EMPTY_MULTI_MAP, OperationTemplateListResponse.class);
     }
 
     @Override
-    public OperationTemplateDetailResponse operationTemplateDetail(OperationTemplateDetailRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/template/detail", request, OperationTemplateDetailResponse.class);
+    public OperationTemplateDetailResponse operationTemplateDetail(OperationTemplateDetailRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/template/detail", request, queryParams, httpHeaders, OperationTemplateDetailResponse.class);
     }
 
     @Override
-    public OperationTemplateDetailResponse createOperationTemplate(OperationTemplateCreateRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/template/create", request, OperationTemplateDetailResponse.class);
+    public OperationTemplateDetailResponse createOperationTemplate(OperationTemplateCreateRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/template/create", request, queryParams, httpHeaders, OperationTemplateDetailResponse.class);
     }
 
     @Override
-    public OperationTemplateDetailResponse updateOperationTemplate(OperationTemplateUpdateRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/template/update", request, OperationTemplateDetailResponse.class);
+    public OperationTemplateDetailResponse updateOperationTemplate(OperationTemplateUpdateRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/template/update", request, queryParams, httpHeaders, OperationTemplateDetailResponse.class);
     }
 
     @Override
-    public Response removeOperationTemplate(OperationTemplateDeleteRequest request) throws PowerAuthClientException {
-        return callV3RestApi("/operation/template/remove", request, Response.class);
+    public Response removeOperationTemplate(OperationTemplateDeleteRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV3RestApi("/operation/template/remove", request, queryParams, httpHeaders, Response.class);
     }
 
     @Override
@@ -1181,10 +1149,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
          *
          * @param path Path of the endpoint.
          * @param request Request object.
+         * @param queryParams HTTP query parameters.
+         * @param httpHeaders HTTP headers.
          * @param responseType Response type.
          * @return Response.
          */
-        private <T> T callV2RestApi(String path, Object request, Class<T> responseType) throws PowerAuthClientException {
+        private <T> T callV2RestApi(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders, Class<T> responseType) throws PowerAuthClientException {
             ObjectRequest<?> objectRequest = new ObjectRequest<>(request);
             try {
                 ObjectResponse<T> objectResponse = restClient.postObject(PA_REST_V2_PREFIX + path, objectRequest, responseType);
@@ -1200,8 +1170,8 @@ public class PowerAuthRestClient implements PowerAuthClient {
         }
 
         @Override
-        public com.wultra.security.powerauth.client.v2.PrepareActivationResponse prepareActivation(com.wultra.security.powerauth.client.v2.PrepareActivationRequest request) throws PowerAuthClientException {
-            return callV2RestApi("/activation/prepare", request, com.wultra.security.powerauth.client.v2.PrepareActivationResponse.class);
+        public com.wultra.security.powerauth.client.v2.PrepareActivationResponse prepareActivation(com.wultra.security.powerauth.client.v2.PrepareActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+            return callV2RestApi("/activation/prepare", request, queryParams, httpHeaders, com.wultra.security.powerauth.client.v2.PrepareActivationResponse.class);
         }
 
         @Override
@@ -1215,12 +1185,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.setExtras(extras);
             request.setApplicationKey(applicationKey);
             request.setApplicationSignature(applicationSignature);
-            return this.prepareActivation(request);
+            return this.prepareActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
         }
 
         @Override
-        public com.wultra.security.powerauth.client.v2.CreateActivationResponse createActivation(com.wultra.security.powerauth.client.v2.CreateActivationRequest request) throws PowerAuthClientException {
-            return callV2RestApi("/activation/create", request, com.wultra.security.powerauth.client.v2.CreateActivationResponse.class);
+        public com.wultra.security.powerauth.client.v2.CreateActivationResponse createActivation(com.wultra.security.powerauth.client.v2.CreateActivationRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+            return callV2RestApi("/activation/create", request, queryParams, httpHeaders, com.wultra.security.powerauth.client.v2.CreateActivationResponse.class);
         }
 
         @Override
@@ -1260,12 +1230,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.setEncryptedDevicePublicKey(cDevicePublicKey);
             request.setExtras(extras);
             request.setApplicationSignature(applicationSignature);
-            return this.createActivation(request);
+            return this.createActivation(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
         }
 
         @Override
-        public com.wultra.security.powerauth.client.v2.VaultUnlockResponse unlockVault(com.wultra.security.powerauth.client.v2.VaultUnlockRequest request) throws PowerAuthClientException {
-            return callV2RestApi("/vault/unlock", request, com.wultra.security.powerauth.client.v2.VaultUnlockResponse.class);
+        public com.wultra.security.powerauth.client.v2.VaultUnlockResponse unlockVault(com.wultra.security.powerauth.client.v2.VaultUnlockRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+            return callV2RestApi("/vault/unlock", request, queryParams, httpHeaders, com.wultra.security.powerauth.client.v2.VaultUnlockResponse.class);
         }
 
         @Override
@@ -1277,12 +1247,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.setSignature(signature);
             request.setSignatureType(signatureType);
             request.setReason(reason);
-            return this.unlockVault(request);
+            return this.unlockVault(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
         }
 
         @Override
-        public com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyResponse generatePersonalizedE2EEncryptionKey(com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyRequest request) throws PowerAuthClientException {
-            return callV2RestApi("/activation/encryption/key/create", request, com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyResponse.class);
+        public com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyResponse generatePersonalizedE2EEncryptionKey(com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+            return callV2RestApi("/activation/encryption/key/create", request, queryParams, httpHeaders, com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyResponse.class);
         }
 
         @Override
@@ -1290,12 +1260,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
             com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyRequest request = new com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyRequest();
             request.setActivationId(activationId);
             request.setSessionIndex(sessionIndex);
-            return this.generatePersonalizedE2EEncryptionKey(request);
+            return this.generatePersonalizedE2EEncryptionKey(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
         }
 
         @Override
-        public com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyResponse generateNonPersonalizedE2EEncryptionKey(com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyRequest request) throws PowerAuthClientException {
-            return callV2RestApi("/application/encryption/key/create", request, com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyResponse.class);
+        public com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyResponse generateNonPersonalizedE2EEncryptionKey(com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+            return callV2RestApi("/application/encryption/key/create", request, queryParams, httpHeaders, com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyResponse.class);
         }
 
         @Override
@@ -1304,12 +1274,12 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.setApplicationKey(applicationKey);
             request.setEphemeralPublicKey(ephemeralPublicKeyBase64);
             request.setSessionIndex(sessionIndex);
-            return this.generateNonPersonalizedE2EEncryptionKey(request);
+            return this.generateNonPersonalizedE2EEncryptionKey(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
         }
 
         @Override
-        public com.wultra.security.powerauth.client.v2.CreateTokenResponse createToken(com.wultra.security.powerauth.client.v2.CreateTokenRequest request) throws PowerAuthClientException {
-            return callV2RestApi("/token/create", request, com.wultra.security.powerauth.client.v2.CreateTokenResponse.class);
+        public com.wultra.security.powerauth.client.v2.CreateTokenResponse createToken(com.wultra.security.powerauth.client.v2.CreateTokenRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+            return callV2RestApi("/token/create", request, queryParams, httpHeaders, com.wultra.security.powerauth.client.v2.CreateTokenResponse.class);
         }
 
         @Override
@@ -1318,7 +1288,7 @@ public class PowerAuthRestClient implements PowerAuthClient {
             request.setActivationId(activationId);
             request.setEphemeralPublicKey(ephemeralPublicKey);
             request.setSignatureType(signatureType);
-            return createToken(request);
+            return createToken(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
         }
     }
 

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClientConfiguration.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClientConfiguration.java
@@ -17,6 +17,9 @@
  */
 package com.wultra.security.powerauth.rest.client;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+
 /**
  * Configuration of PowerAuth REST client.
  *
@@ -37,6 +40,10 @@ public class PowerAuthRestClientConfiguration {
     private String powerAuthClientToken;
     private String powerAuthClientSecret;
     private boolean acceptInvalidSslCertificate;
+    private HttpHeaders defaultHttpHeaders;
+    private ExchangeFilterFunction filter;
+    private boolean resetQueryParams;
+    private boolean resetHttpHeaders;
 
     /**
      * Get maximum memory size for HTTP requests in bytes.
@@ -196,5 +203,69 @@ public class PowerAuthRestClientConfiguration {
      */
     public void setAcceptInvalidSslCertificate(boolean acceptInvalidSslCertificate) {
         this.acceptInvalidSslCertificate = acceptInvalidSslCertificate;
+    }
+
+    /**
+     * Get default HTTP headers.
+     * @return Default HTTP headers.
+     */
+    public HttpHeaders getDefaultHttpHeaders() {
+        return defaultHttpHeaders;
+    }
+
+    /**
+     * Set default HTTP headers.
+     * @param defaultHttpHeaders Default HTTP headers.
+     */
+    public void setDefaultHttpHeaders(HttpHeaders defaultHttpHeaders) {
+        this.defaultHttpHeaders = defaultHttpHeaders;
+    }
+
+    /**
+     * Get exchange filter function.
+     * @return Exchange filter function.
+     */
+    public ExchangeFilterFunction getFilter() {
+        return filter;
+    }
+
+    /**
+     * Set exchange filter function.
+     * @param filter Exchange filter function.
+     */
+    public void setFilter(ExchangeFilterFunction filter) {
+        this.filter = filter;
+    }
+
+    /**
+     * Get whether query parameters should be reset after each REST API call.
+     * @return Whether query parameters should be reset after each REST API call.
+     */
+    public boolean isResetQueryParams() {
+        return resetQueryParams;
+    }
+
+    /**
+     * Set whether query parameters should be reset after each REST API call.
+     * @param resetQueryParams Whether query parameters should be reset after each REST API call.
+     */
+    public void setResetQueryParams(boolean resetQueryParams) {
+        this.resetQueryParams = resetQueryParams;
+    }
+
+    /**
+     * Get whether HTTP headers should be reset after each REST API call.
+     * @return Whether query parameters should be reset after each REST API call.
+     */
+    public boolean isResetHttpHeaders() {
+        return resetHttpHeaders;
+    }
+
+    /**
+     * Set whether query parameters should be reset after each REST API call.
+     * @param resetHttpHeaders Whether query parameters should be reset after each REST API call.
+     */
+    public void setResetHttpHeaders(boolean resetHttpHeaders) {
+        this.resetHttpHeaders = resetHttpHeaders;
     }
 }

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClientConfiguration.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClientConfiguration.java
@@ -237,35 +237,4 @@ public class PowerAuthRestClientConfiguration {
         this.filter = filter;
     }
 
-    /**
-     * Get whether query parameters should be reset after each REST API call.
-     * @return Whether query parameters should be reset after each REST API call.
-     */
-    public boolean isResetQueryParams() {
-        return resetQueryParams;
-    }
-
-    /**
-     * Set whether query parameters should be reset after each REST API call.
-     * @param resetQueryParams Whether query parameters should be reset after each REST API call.
-     */
-    public void setResetQueryParams(boolean resetQueryParams) {
-        this.resetQueryParams = resetQueryParams;
-    }
-
-    /**
-     * Get whether HTTP headers should be reset after each REST API call.
-     * @return Whether query parameters should be reset after each REST API call.
-     */
-    public boolean isResetHttpHeaders() {
-        return resetHttpHeaders;
-    }
-
-    /**
-     * Set whether query parameters should be reset after each REST API call.
-     * @param resetHttpHeaders Whether query parameters should be reset after each REST API call.
-     */
-    public void setResetHttpHeaders(boolean resetHttpHeaders) {
-        this.resetHttpHeaders = resetHttpHeaders;
-    }
 }

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClientConfiguration.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClientConfiguration.java
@@ -42,8 +42,6 @@ public class PowerAuthRestClientConfiguration {
     private boolean acceptInvalidSslCertificate;
     private HttpHeaders defaultHttpHeaders;
     private ExchangeFilterFunction filter;
-    private boolean resetQueryParams;
-    private boolean resetHttpHeaders;
 
     /**
      * Get maximum memory size for HTTP requests in bytes.


### PR DESCRIPTION
- Fix #673: Allow specifying query parameters and HTTP headers in REST client calls
- Fix #684: Add support for logging using correlation ID with MDC