### PR TITLE
Fix #710: Inherit activation flags when recovering activation

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/PowerAuthClient.java
@@ -187,16 +187,18 @@ public interface PowerAuthClient {
     /**
      * Call the prepareActivation method of the PowerAuth 3.0 Server interface.
      *
-     * @param activationCode     Activation code.
-     * @param applicationKey     Application key.
-     * @param ephemeralPublicKey Ephemeral key for ECIES.
-     * @param encryptedData      Encrypted data for ECIES.
-     * @param mac                Mac of key and data for ECIES.
-     * @param nonce              Nonce for ECIES.
+     * @param activationCode                Activation code.
+     * @param applicationKey                Application key.
+     * @param shouldGenerateRecoveryCodes   Flag indicating if recovery codes should be generated. If null value is provided,
+     *                                      server settings property is used to determine if recovery codes should be generated.
+     * @param ephemeralPublicKey            Ephemeral key for ECIES.
+     * @param encryptedData                 Encrypted data for ECIES.
+     * @param mac                           Mac of key and data for ECIES.
+     * @param nonce                         Nonce for ECIES.
      * @return {@link PrepareActivationResponse}
      * @throws PowerAuthClientException In case REST API call fails.
      */
-    PrepareActivationResponse prepareActivation(String activationCode, String applicationKey, String ephemeralPublicKey, String encryptedData, String mac, String nonce) throws PowerAuthClientException;
+    PrepareActivationResponse prepareActivation(String activationCode, String applicationKey, Boolean shouldGenerateRecoveryCodes, String ephemeralPublicKey, String encryptedData, String mac, String nonce) throws PowerAuthClientException;
 
     /**
      * Create a new activation directly, using the createActivation method of the PowerAuth Server

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
@@ -402,6 +402,7 @@ public class ActivationServiceBehavior {
                     activationExpireTimestamp,
                     ActivationOtpValidation.NONE,
                     null,
+                    null,
                     keyConversionUtilities);
             String activationId = initResponse.getActivationId();
             ActivationRecordEntity activation = activationRepository.findActivationWithLock(activationId);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -340,6 +340,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             // Get request parameters
             final String userId = request.getUserId();
             final Date activationExpireTimestamp = XMLGregorianCalendarConverter.convertTo(request.getTimestampActivationExpire());
+            final Boolean shouldGenerateRecoveryCodes = request.isGenerateRecoveryCodes();
             final Long maxFailedCount = request.getMaxFailureCount();
             final String applicationKey = request.getApplicationKey();
             final String activationOtp = request.getActivationOtp();
@@ -352,6 +353,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             final CreateActivationResponse response = behavior.getActivationServiceBehavior().createActivation(
                     userId,
                     activationExpireTimestamp,
+                    shouldGenerateRecoveryCodes,
                     maxFailedCount,
                     applicationKey,
                     cryptogram,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -279,6 +279,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
                     activationExpireTimestamp,
                     activationOtpValidation,
                     activationOtp,
+                    null,
                     keyConvertor);
             logger.info("InitActivationRequest succeeded");
             return response;
@@ -305,13 +306,14 @@ public class PowerAuthServiceImpl implements PowerAuthService {
         try {
             final String activationCode = request.getActivationCode();
             final String applicationKey = request.getApplicationKey();
+            final Boolean shouldGenerateRecoveryCodes = request.isGenerateRecoveryCodes();
             final byte[] ephemeralPublicKey = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
             final byte[] mac = BaseEncoding.base64().decode(request.getMac());
             final byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
             final byte[] nonce = request.getNonce() != null ? BaseEncoding.base64().decode(request.getNonce()) : null;
             final EciesCryptogram cryptogram = new EciesCryptogram(ephemeralPublicKey, mac, encryptedData, nonce);
             logger.info("PrepareActivationRequest received, activation code: {}", activationCode);
-            final PrepareActivationResponse response = behavior.getActivationServiceBehavior().prepareActivation(activationCode, applicationKey, cryptogram, keyConvertor);
+            final PrepareActivationResponse response = behavior.getActivationServiceBehavior().prepareActivation(activationCode, applicationKey, shouldGenerateRecoveryCodes, cryptogram, keyConvertor);
             logger.info("PrepareActivationRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -326,6 +326,7 @@
             <xs:sequence>
                 <xs:element name="activationCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="generateRecoveryCodes" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="encryptedData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="mac" type="xs:string" minOccurs="1" maxOccurs="1"/>

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -361,6 +361,7 @@
             <xs:sequence>
                 <xs:element name="userId" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="timestampActivationExpire" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="generateRecoveryCodes" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="maxFailureCount" type="xs:long" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="ephemeralPublicKey" type="xs:string" minOccurs="1" maxOccurs="1"/>
@@ -1493,6 +1494,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="generateRecoveryCodes" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="recoveryCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="puk" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="applicationKey" type="xs:string" minOccurs="1" maxOccurs="1"/>

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/PowerAuthRestClient.java
@@ -274,10 +274,11 @@ public class PowerAuthRestClient implements PowerAuthClient {
     }
 
     @Override
-    public PrepareActivationResponse prepareActivation(String activationCode, String applicationKey, String ephemeralPublicKey, String encryptedData, String mac, String nonce) throws PowerAuthClientException {
+    public PrepareActivationResponse prepareActivation(String activationCode, String applicationKey, Boolean shouldGenerateRecoveryCodes, String ephemeralPublicKey, String encryptedData, String mac, String nonce) throws PowerAuthClientException {
         PrepareActivationRequest request = new PrepareActivationRequest();
         request.setActivationCode(activationCode);
         request.setApplicationKey(applicationKey);
+        request.setGenerateRecoveryCodes(shouldGenerateRecoveryCodes);
         request.setEphemeralPublicKey(ephemeralPublicKey);
         request.setEncryptedData(encryptedData);
         request.setMac(mac);


### PR DESCRIPTION
The pull request addresses two areas:

- We inherit activation flags when creating a new operation using recovery codes that are linked to an activation.
- We allow specifying if recovery codes should be created using `prepareActivation`/`createActivation`/`createActivationUsingRecoveryCode` call.

The reason is the following:

- When we have activation that uses flags to mark it is "partially completed", we must make sure descendant activation is also marked like this.
- When recovering activation on old mobile client versions that does not support "partially completed" activation flag yet, we want to have a mechanism in place to assure that the "partially completed" activation does not create recovery codes.