### PR TITLE
Fix #764: Return activation status in ValidateTokenResponse

### DIFF
--- a/docs/PowerAuth-Server-1.4.0.md
+++ b/docs/PowerAuth-Server-1.4.0.md
@@ -1,0 +1,9 @@
+# Migration from 1.3.x to 1.4.0
+
+This guide contains instructions for migration from PowerAuth Server version `1.3.x` to version `1.4.0`.
+
+## Change in PowerAuth Token Verification
+
+In earlier versions of PowerAuth Server, the token verification endpoint `/rest/v3/token/validate` returned an error in case the activation used by the token was not active. In order to always return activation status as part of the response, we changed the endpoint behaviour and removed the error handling for inactive activations. This change unifies the business logic with signature verification endpoint.
+
+Adaptation to this change is required only in case this endpoint is called directly on PowerAuth server. In case you use the @PowerAuthToken annotation for token validation, no changes are required.

--- a/docs/PowerAuth-Server-1.4.0.md
+++ b/docs/PowerAuth-Server-1.4.0.md
@@ -6,4 +6,4 @@ This guide contains instructions for migration from PowerAuth Server version `1.
 
 In earlier versions of PowerAuth Server, the token verification endpoint `/rest/v3/token/validate` returned an error in case the activation used by the token was not active. In order to always return activation status as part of the response, we changed the endpoint behaviour and removed the error handling for inactive activations. This change unifies the business logic with signature verification endpoint.
 
-Adaptation to this change is required only in case this endpoint is called directly on PowerAuth server. In case you use the @PowerAuthToken annotation for token validation, no changes are required.
+Adaptation to this change is required only in case this endpoint is called directly on PowerAuth server. In case you use the `@PowerAuthToken` annotation for token validation, no changes are required.

--- a/docs/PowerAuth-Server-1.4.0.md
+++ b/docs/PowerAuth-Server-1.4.0.md
@@ -6,4 +6,27 @@ This guide contains instructions for migration from PowerAuth Server version `1.
 
 In earlier versions of PowerAuth Server, the token verification endpoint `/rest/v3/token/validate` returned an error in case the activation used by the token was not active. In order to always return activation status as part of the response, we changed the endpoint behaviour and removed the error handling for inactive activations. This change unifies the business logic with signature verification endpoint.
 
+Before change:
+
+```java
+try {
+    final ValidateTokenResponse response = powerauthClient.validateToken(request);
+    // regular business logic
+} catch (PowerAuthClientException ex) {
+    // error handling for inactive activation and all other errors
+}
+```
+
+After change:
+```java
+try {
+    final ValidateTokenResponse response = powerauthClient.validateToken(request);
+    if (response.activationStatus != ActivationStatus.ACTIVE) {
+        // error handling for inactive activations
+    }
+} catch (PowerAuthClientException ex) {
+    // error handling for all other errors
+}
+```
+
 Adaptation to this change is required only in case this endpoint is called directly on PowerAuth server. In case you use the `@PowerAuthToken` annotation for token validation, no changes are required.

--- a/docs/PowerAuth-Server-1.4.0.md
+++ b/docs/PowerAuth-Server-1.4.0.md
@@ -21,7 +21,7 @@ After change:
 ```java
 try {
     final ValidateTokenResponse response = powerauthClient.validateToken(request);
-    if (response.activationStatus != ActivationStatus.ACTIVE) {
+    if (response.getActivationStatus() != ActivationStatus.ACTIVE) {
         // error handling for inactive activations
     }
 } catch (PowerAuthClientException ex) {

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/TokenBehavior.java
@@ -287,7 +287,7 @@ public class TokenBehavior {
 
             final ValidateTokenResponse response = new ValidateTokenResponse();
             response.setTokenValid(isTokenValid);
-            response.setActivationStatus(activationStatusConverter.convert(ActivationStatus.ACTIVE));
+            response.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));
             response.setBlockedReason(activation.getBlockedReason());
             response.setActivationId(activation.getActivationId());
             response.setApplicationId(activation.getApplication().getId());

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -1237,6 +1237,8 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="tokenValid" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="activationStatus" type="tns:ActivationStatus" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="blockedReason" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="activationId" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="userId" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="applicationId" type="xs:string" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
Unify response data and logic for signature verification and token verification.