### PR TITLE
Fix #858: Prefer Java 8 APIs over Guava

### DIFF
--- a/powerauth-admin/src/main/java/io/getlime/security/app/admin/converter/SignatureAuditItemConverter.java
+++ b/powerauth-admin/src/main/java/io/getlime/security/app/admin/converter/SignatureAuditItemConverter.java
@@ -16,11 +16,11 @@
 
 package io.getlime.security.app.admin.converter;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v3.SignatureAuditResponse;
 import io.getlime.security.app.admin.model.SignatureAuditItem;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * Converter for signature audit items.
@@ -57,7 +57,7 @@ public class SignatureAuditItemConverter {
         result.setTimestampCreated(signatureAuditItem.getTimestampCreated().toGregorianCalendar().getTime());
 
         // Special handling for base-64 encoded signature data - data needs to be decoded.
-        result.setData(new String(BaseEncoding.base64().decode(signatureAuditItem.getDataBase64()), StandardCharsets.UTF_8));
+        result.setData(new String(Base64.getDecoder().decode(signatureAuditItem.getDataBase64()), StandardCharsets.UTF_8));
         // Unstructured signature data is decoded and set as structured signature data.
         result.setSignatureData(signatureDataConverter.fromSignatureDataBase64(result.getData()));
 

--- a/powerauth-admin/src/main/java/io/getlime/security/app/admin/converter/SignatureDataConverter.java
+++ b/powerauth-admin/src/main/java/io/getlime/security/app/admin/converter/SignatureDataConverter.java
@@ -16,12 +16,12 @@
 
 package io.getlime.security.app.admin.converter;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.app.admin.model.SignatureData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * Converter for signature data.
@@ -48,10 +48,10 @@ public class SignatureDataConverter {
         try {
             SignatureData signatureData = new SignatureData();
             signatureData.setRequestMethod(normalizeTextForHTML(parts[0]));
-            signatureData.setRequestURIIdentifier(normalizeTextForHTML(new String(BaseEncoding.base64().decode(parts[1]), StandardCharsets.UTF_8)));
-            signatureData.setNonce(normalizeTextForHTML(new String(BaseEncoding.base64().decode(parts[2]), StandardCharsets.UTF_8)));
-            signatureData.setRequestBody(normalizeTextForHTML(new String(BaseEncoding.base64().decode(parts[3]), StandardCharsets.UTF_8)));
-            signatureData.setApplicationSecret(normalizeTextForHTML(new String(BaseEncoding.base64().decode(parts[4]), StandardCharsets.UTF_8)));
+            signatureData.setRequestURIIdentifier(normalizeTextForHTML(new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8)));
+            signatureData.setNonce(normalizeTextForHTML(new String(Base64.getDecoder().decode(parts[2]), StandardCharsets.UTF_8)));
+            signatureData.setRequestBody(normalizeTextForHTML(new String(Base64.getDecoder().decode(parts[3]), StandardCharsets.UTF_8)));
+            signatureData.setApplicationSecret(normalizeTextForHTML(new String(Base64.getDecoder().decode(parts[4]), StandardCharsets.UTF_8)));
             return signatureData;
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid signature data: {}", signatureDataBase64);

--- a/powerauth-admin/src/main/java/io/getlime/security/app/admin/util/QRUtil.java
+++ b/powerauth-admin/src/main/java/io/getlime/security/app/admin/util/QRUtil.java
@@ -16,7 +16,6 @@
 
 package io.getlime.security.app.admin.util;
 
-import com.google.common.io.BaseEncoding;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.WriterException;
@@ -28,6 +27,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * Utility class for generating QR codes.
@@ -55,7 +55,7 @@ public class QRUtil {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ImageIO.write(image, "png", baos);
             byte[] bytes = baos.toByteArray();
-            return "data:image/png;base64," + BaseEncoding.base64().encode(bytes);
+            return "data:image/png;base64," + Base64.getEncoder().encodeToString(bytes);
         } catch (WriterException | IOException e) {
             e.printStackTrace();
         }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/converter/v3/RecoveryPukConverter.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/converter/v3/RecoveryPukConverter.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.converter.v3;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.app.server.configuration.PowerAuthServiceConfiguration;
 import io.getlime.security.powerauth.app.server.database.model.EncryptionMode;
 import io.getlime.security.powerauth.app.server.database.model.RecoveryPuk;
@@ -40,6 +39,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.util.Arrays;
+import java.util.Base64;
 
 /**
  * Converter for recovery PUK which handles record encryption and decryption in case it is configured.
@@ -104,13 +104,13 @@ public class RecoveryPukConverter {
 
                 try {
                     // Convert master DB encryption key
-                    SecretKey masterDbEncryptionKey = keyConvertor.convertBytesToSharedSecretKey(BaseEncoding.base64().decode(masterDbEncryptionKeyBase64));
+                    SecretKey masterDbEncryptionKey = keyConvertor.convertBytesToSharedSecretKey(Base64.getDecoder().decode(masterDbEncryptionKeyBase64));
 
                     // Derive secret key from master DB encryption key, userId and activationId
                     SecretKey secretKey = deriveSecretKey(masterDbEncryptionKey, applicationRid, userId, recoveryCode, pukIndex);
 
                     // Base64-decode PUK hash
-                    byte[] pukHashBytes = BaseEncoding.base64().decode(pukHashFromDB);
+                    byte[] pukHashBytes = Base64.getDecoder().decode(pukHashFromDB);
 
                     // Check that the length of the byte array is sufficient to avoid AIOOBE on the next calls
                     if (pukHashBytes.length < 16) {
@@ -175,7 +175,7 @@ public class RecoveryPukConverter {
 
         try {
             // Convert master DB encryption key
-            SecretKey masterDbEncryptionKey = keyConvertor.convertBytesToSharedSecretKey(BaseEncoding.base64().decode(masterDbEncryptionKeyBase64));
+            SecretKey masterDbEncryptionKey = keyConvertor.convertBytesToSharedSecretKey(Base64.getDecoder().decode(masterDbEncryptionKeyBase64));
 
             // Derive secret key from master DB encryption key, userId and activationId
             SecretKey secretKey = deriveSecretKey(masterDbEncryptionKey, applicationRid, userId, recoveryCode, pukIndex);
@@ -193,7 +193,7 @@ public class RecoveryPukConverter {
             byte[] encryptedData = baos.toByteArray();
 
             // Base64-encode output and create ServerPrivateKey instance
-            String encryptedPukHashBase64 = BaseEncoding.base64().encode(encryptedData);
+            String encryptedPukHashBase64 = Base64.getEncoder().encodeToString(encryptedData);
 
             // Return encrypted record including encryption mode
             return new RecoveryPuk(EncryptionMode.AES_HMAC, encryptedPukHashBase64);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/ActivationServiceBehavior.java
@@ -18,7 +18,6 @@
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v2;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v2.CreateActivationResponse;
 import com.wultra.security.powerauth.client.v2.PrepareActivationResponse;
 import com.wultra.security.powerauth.client.v3.ActivationOtpValidation;
@@ -50,6 +49,7 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
@@ -242,19 +242,19 @@ public class ActivationServiceBehavior {
 
             // Get master private key
             String masterPrivateKeyBase64 = activation.getMasterKeyPair().getMasterKeyPrivateBase64();
-            byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
+            byte[] masterPrivateKeyBytes = Base64.getDecoder().decode(masterPrivateKeyBase64);
             PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
 
             // Get client ephemeral public key
             PublicKey clientEphemeralPublicKey = null;
             if (clientEphemeralPublicKeyBase64 != null) { // additional encryption is used
-                byte[] clientEphemeralPublicKeyBytes = BaseEncoding.base64().decode(clientEphemeralPublicKeyBase64);
+                byte[] clientEphemeralPublicKeyBytes = Base64.getDecoder().decode(clientEphemeralPublicKeyBase64);
                 clientEphemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(clientEphemeralPublicKeyBytes);
             }
 
             // Decrypt the device public key
-            byte[] C_devicePublicKey = BaseEncoding.base64().decode(cDevicePublicKeyBase64);
-            byte[] activationNonce = BaseEncoding.base64().decode(activationNonceBase64);
+            byte[] C_devicePublicKey = Base64.getDecoder().decode(cDevicePublicKeyBase64);
+            byte[] activationNonce = Base64.getDecoder().decode(activationNonceBase64);
 
             PublicKey devicePublicKey = null;
             try {
@@ -270,14 +270,14 @@ public class ActivationServiceBehavior {
                 handleInvalidPublicKey(activation);
             }
 
-            byte[] applicationSignatureBytes = BaseEncoding.base64().decode(applicationSignature);
+            byte[] applicationSignatureBytes = Base64.getDecoder().decode(applicationSignature);
 
             if (!powerAuthServerActivation.validateApplicationSignature(
                     activationIdShort,
                     activationNonce,
                     C_devicePublicKey,
-                    BaseEncoding.base64().decode(applicationKey),
-                    BaseEncoding.base64().decode(applicationVersion.getApplicationSecret()),
+                    Base64.getDecoder().decode(applicationKey),
+                    Base64.getDecoder().decode(applicationVersion.getApplicationSecret()),
                     applicationSignatureBytes)) {
                 logger.warn("Activation signature is invalid, activation ID short: {}", activationIdShort);
                 // Rollback is not required, error occurs before writing to database
@@ -287,7 +287,7 @@ public class ActivationServiceBehavior {
             // Generate response data before writing to database to avoid rollbacks
             byte[] activationNonceServer = powerAuthServerActivation.generateActivationNonce();
             String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
-            PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
+            PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(Base64.getDecoder().decode(serverPublicKeyBase64));
             KeyPair ephemeralKeyPair = new KeyGenerator().generateKeyPair();
             PrivateKey ephemeralPrivateKey = ephemeralKeyPair.getPrivate();
             PublicKey ephemeralPublicKey = ephemeralKeyPair.getPublic();
@@ -304,7 +304,7 @@ public class ActivationServiceBehavior {
 
             // Update and persist the activation record
             activation.setActivationStatus(ActivationStatus.PENDING_COMMIT);
-            activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
             activation.setActivationName(activationName);
             activation.setExtras(extras);
             // PowerAuth protocol version 2.0 and 2.1 uses 0x2 as version in activation status
@@ -316,10 +316,10 @@ public class ActivationServiceBehavior {
             // Compute the response
             PrepareActivationResponse response = new PrepareActivationResponse();
             response.setActivationId(activation.getActivationId());
-            response.setActivationNonce(BaseEncoding.base64().encode(activationNonceServer));
-            response.setEncryptedServerPublicKey(BaseEncoding.base64().encode(C_serverPublicKey));
-            response.setEncryptedServerPublicKeySignature(BaseEncoding.base64().encode(C_serverPubKeySignature));
-            response.setEphemeralPublicKey(BaseEncoding.base64().encode(ephemeralPublicKeyBytes));
+            response.setActivationNonce(Base64.getEncoder().encodeToString(activationNonceServer));
+            response.setEncryptedServerPublicKey(Base64.getEncoder().encodeToString(C_serverPublicKey));
+            response.setEncryptedServerPublicKeySignature(Base64.getEncoder().encodeToString(C_serverPubKeySignature));
+            response.setEphemeralPublicKey(Base64.getEncoder().encodeToString(ephemeralPublicKeyBytes));
 
             return response;
         } catch (InvalidKeySpecException | InvalidKeyException ex) {
@@ -423,19 +423,19 @@ public class ActivationServiceBehavior {
 
             // Get master private key
             String masterPrivateKeyBase64 = activation.getMasterKeyPair().getMasterKeyPrivateBase64();
-            byte[] masterPrivateKeyBytes = BaseEncoding.base64().decode(masterPrivateKeyBase64);
+            byte[] masterPrivateKeyBytes = Base64.getDecoder().decode(masterPrivateKeyBase64);
             PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(masterPrivateKeyBytes);
 
             // Get client ephemeral public key
             PublicKey clientEphemeralPublicKey = null;
             if (clientEphemeralPublicKeyBase64 != null) { // additional encryption is used
-                byte[] clientEphemeralPublicKeyBytes = BaseEncoding.base64().decode(clientEphemeralPublicKeyBase64);
+                byte[] clientEphemeralPublicKeyBytes = Base64.getDecoder().decode(clientEphemeralPublicKeyBase64);
                 clientEphemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(clientEphemeralPublicKeyBytes);
             }
 
             // Decrypt the device public key
-            byte[] C_devicePublicKey = BaseEncoding.base64().decode(cDevicePublicKeyBase64);
-            byte[] activationNonce = BaseEncoding.base64().decode(activationNonceBase64);
+            byte[] C_devicePublicKey = Base64.getDecoder().decode(cDevicePublicKeyBase64);
+            byte[] activationNonce = Base64.getDecoder().decode(activationNonceBase64);
 
             PublicKey devicePublicKey;
             try {
@@ -453,14 +453,14 @@ public class ActivationServiceBehavior {
                 throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
             }
 
-            byte[] applicationSignatureBytes = BaseEncoding.base64().decode(applicationSignature);
+            byte[] applicationSignatureBytes = Base64.getDecoder().decode(applicationSignature);
 
             if (!powerAuthServerActivation.validateApplicationSignature(
                     identity,
                     activationNonce,
                     C_devicePublicKey,
-                    BaseEncoding.base64().decode(applicationKey),
-                    BaseEncoding.base64().decode(applicationVersion.getApplicationSecret()),
+                    Base64.getDecoder().decode(applicationKey),
+                    Base64.getDecoder().decode(applicationVersion.getApplicationSecret()),
                     applicationSignatureBytes)) {
                 logger.warn("Activation signature is invalid, activation ID: {}", activationId);
                 // Activation signature is invalid, rollback this transaction
@@ -469,7 +469,7 @@ public class ActivationServiceBehavior {
 
             // Update and persist the activation record
             activation.setActivationStatus(ActivationStatus.PENDING_COMMIT);
-            activation.setDevicePublicKeyBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConversionUtilities.convertPublicKeyToBytes(devicePublicKey)));
             activation.setActivationName(activationName);
             activation.setExtras(extras);
             // PowerAuth protocol version 2.0 and 2.1 uses 0x2 as version
@@ -482,7 +482,7 @@ public class ActivationServiceBehavior {
             // Generate response data
             byte[] activationNonceServer = powerAuthServerActivation.generateActivationNonce();
             String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
-            PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(serverPublicKeyBase64));
+            PublicKey serverPublicKey = keyConversionUtilities.convertBytesToPublicKey(Base64.getDecoder().decode(serverPublicKeyBase64));
             KeyPair ephemeralKeyPair = new KeyGenerator().generateKeyPair();
             PrivateKey ephemeralPrivateKey = ephemeralKeyPair.getPrivate();
             PublicKey ephemeralPublicKey = ephemeralKeyPair.getPublic();
@@ -500,10 +500,10 @@ public class ActivationServiceBehavior {
             // Compute the response
             CreateActivationResponse response = new CreateActivationResponse();
             response.setActivationId(activation.getActivationId());
-            response.setActivationNonce(BaseEncoding.base64().encode(activationNonceServer));
-            response.setEncryptedServerPublicKey(BaseEncoding.base64().encode(C_serverPublicKey));
-            response.setEncryptedServerPublicKeySignature(BaseEncoding.base64().encode(C_serverPubKeySignature));
-            response.setEphemeralPublicKey(BaseEncoding.base64().encode(ephemeralPublicKeyBytes));
+            response.setActivationNonce(Base64.getEncoder().encodeToString(activationNonceServer));
+            response.setEncryptedServerPublicKey(Base64.getEncoder().encodeToString(C_serverPublicKey));
+            response.setEncryptedServerPublicKeySignature(Base64.getEncoder().encodeToString(C_serverPubKeySignature));
+            response.setEphemeralPublicKey(Base64.getEncoder().encodeToString(ephemeralPublicKeyBytes));
 
             return response;
         } catch (InvalidKeySpecException | InvalidKeyException ex) {

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/EncryptionServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/EncryptionServiceBehavior.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v2;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v2.GetNonPersonalizedEncryptionKeyResponse;
 import com.wultra.security.powerauth.client.v2.GetPersonalizedEncryptionKeyResponse;
 import io.getlime.security.powerauth.app.server.converter.v3.ServerPrivateKeyConverter;
@@ -50,6 +49,7 @@ import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 /**
  * Behavior class implementing the end-to-end encryption related processes. The
@@ -122,8 +122,8 @@ public class EncryptionServiceBehavior {
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activationId);
 
             // Convert the keys
-            PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(BaseEncoding.base64().decode(devicePublicKeyBase64));
-            PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(BaseEncoding.base64().decode(serverPrivateKeyBase64));
+            PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(Base64.getDecoder().decode(devicePublicKeyBase64));
+            PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(Base64.getDecoder().decode(serverPrivateKeyBase64));
 
             SecretKey masterKey = powerAuthServerKeyFactory.generateServerMasterSecretKey(serverPrivateKey, devicePublicKey);
             SecretKey masterTransportKey = powerAuthServerKeyFactory.generateServerTransportKey(masterKey);
@@ -134,7 +134,7 @@ public class EncryptionServiceBehavior {
             // Use provided index or generate own, if not provided.
             byte[] sessionIndexBytes = null;
             if (sessionIndex != null) {
-                sessionIndexBytes = BaseEncoding.base64().decode(sessionIndex);
+                sessionIndexBytes = Base64.getDecoder().decode(sessionIndex);
             }
             byte[] index;
             if (sessionIndexBytes == null || sessionIndexBytes.length != 16) {
@@ -146,8 +146,8 @@ public class EncryptionServiceBehavior {
             byte[] tmpBytes = new HMACHashUtilities().hash(index, masterTransportKeyData);
             byte[] derivedTransportKeyBytes = keyGenerator.convert32Bto16B(tmpBytes);
 
-            String indexBase64 = BaseEncoding.base64().encode(index);
-            String derivedTransportKeyBase64 = BaseEncoding.base64().encode(derivedTransportKeyBytes);
+            String indexBase64 = Base64.getEncoder().encodeToString(index);
+            String derivedTransportKeyBase64 = Base64.getEncoder().encodeToString(derivedTransportKeyBytes);
 
             GetPersonalizedEncryptionKeyResponse response = new GetPersonalizedEncryptionKeyResponse();
             response.setActivationId(activation.getActivationId());
@@ -200,11 +200,11 @@ public class EncryptionServiceBehavior {
                 throw localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
             }
 
-            byte[] ephemeralKeyBytes = BaseEncoding.base64().decode(ephemeralPublicKeyBase64);
+            byte[] ephemeralKeyBytes = Base64.getDecoder().decode(ephemeralPublicKeyBase64);
             PublicKey ephemeralPublicKey = keyConversionUtilities.convertBytesToPublicKey(ephemeralKeyBytes);
 
             String masterPrivateKeyBase64 = keypair.getMasterKeyPrivateBase64();
-            PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(BaseEncoding.base64().decode(masterPrivateKeyBase64));
+            PrivateKey masterPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
 
             SecretKey masterKey = powerAuthServerKeyFactory.generateServerMasterSecretKey(masterPrivateKey, ephemeralPublicKey);
             byte[] masterTransportKeyData = keyConversionUtilities.convertSharedSecretKeyToBytes(masterKey);
@@ -214,7 +214,7 @@ public class EncryptionServiceBehavior {
             // Use provided index or generate own, if not provided.
             byte[] sessionIndexBytes = null;
             if (sessionIndexBase64 != null) {
-                sessionIndexBytes = BaseEncoding.base64().decode(sessionIndexBase64);
+                sessionIndexBytes = Base64.getDecoder().decode(sessionIndexBase64);
             }
             byte[] index;
             if (sessionIndexBytes == null || sessionIndexBytes.length != 16) {
@@ -226,8 +226,8 @@ public class EncryptionServiceBehavior {
             byte[] tmpBytes = new HMACHashUtilities().hash(index, masterTransportKeyData);
             byte[] derivedTransportKeyBytes = keyGenerator.convert32Bto16B(tmpBytes);
 
-            String indexBase64 = BaseEncoding.base64().encode(index);
-            String derivedTransportKeyBase64 = BaseEncoding.base64().encode(derivedTransportKeyBytes);
+            String indexBase64 = Base64.getEncoder().encodeToString(index);
+            String derivedTransportKeyBase64 = Base64.getEncoder().encodeToString(derivedTransportKeyBytes);
 
             GetNonPersonalizedEncryptionKeyResponse response = new GetNonPersonalizedEncryptionKeyResponse();
             response.setApplicationKey(applicationKey);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/TokenBehavior.java
@@ -19,7 +19,6 @@ package io.getlime.security.powerauth.app.server.service.behavior.tasks.v2;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v2.CreateTokenRequest;
 import com.wultra.security.powerauth.client.v2.CreateTokenResponse;
 import com.wultra.security.powerauth.client.v2.SignatureType;
@@ -47,6 +46,7 @@ import org.springframework.stereotype.Component;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Optional;
 
@@ -106,8 +106,8 @@ public class TokenBehavior {
         EciesCryptogram eciesCryptogram = createToken(activationId, ephemeralPublicKeyBase64, signatureType.value(), keyConversion);
 
         final CreateTokenResponse response = new CreateTokenResponse();
-        response.setMac(BaseEncoding.base64().encode(eciesCryptogram.getMac()));
-        response.setEncryptedData(BaseEncoding.base64().encode(eciesCryptogram.getEncryptedData()));
+        response.setMac(Base64.getEncoder().encodeToString(eciesCryptogram.getMac()));
+        response.setEncryptedData(Base64.getEncoder().encodeToString(eciesCryptogram.getEncryptedData()));
         return response;
     }
 
@@ -149,8 +149,8 @@ public class TokenBehavior {
             final String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
 
             // KEY_SERVER_MASTER_PRIVATE is used in Crypto version 2.0 for ECIES, note that in version 3.0 KEY_SERVER_PRIVATE is used
-            final PrivateKey privateKey = keyConversion.convertBytesToPrivateKey(BaseEncoding.base64().decode(masterPrivateKeyBase64));
-            final byte[] ephemeralPublicKeyBytes = BaseEncoding.base64().decode(ephemeralPublicKeyBase64);
+            final PrivateKey privateKey = keyConversion.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
+            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(ephemeralPublicKeyBase64);
 
             // Generate unique token ID.
             String tokenId = null;
@@ -174,7 +174,7 @@ public class TokenBehavior {
             decryptor.initEnvelopeKey(ephemeralPublicKeyBytes);
 
             // Perform the following operations before writing to database to avoid rollbacks
-            String tokenSecret = BaseEncoding.base64().encode(tokenGenerator.generateTokenSecret());
+            String tokenSecret = Base64.getEncoder().encodeToString(tokenGenerator.generateTokenSecret());
             final TokenInfo tokenInfo = new TokenInfo();
             tokenInfo.setTokenId(tokenId);
             tokenInfo.setTokenSecret(tokenSecret);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v2/VaultUnlockServiceBehavior.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v2;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v2.VaultUnlockResponse;
 import io.getlime.security.powerauth.app.server.converter.v2.ActivationStatusConverter;
 import io.getlime.security.powerauth.app.server.converter.v3.ServerPrivateKeyConverter;
@@ -44,6 +43,7 @@ import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 /**
  * Behavior class implementing the vault unlock related processes. The class separates the
@@ -112,8 +112,8 @@ public class VaultUnlockServiceBehavior {
                     String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activationId);
 
                     // Get the server private and device public keys as byte[]
-                    byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(serverPrivateKeyBase64);
-                    byte[] devicePublicKeyBytes = BaseEncoding.base64().decode(activation.getDevicePublicKeyBase64());
+                    byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
+                    byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
                     PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(serverPrivateKeyBytes);
                     PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(devicePublicKeyBytes);
 
@@ -133,7 +133,7 @@ public class VaultUnlockServiceBehavior {
                     response.setRemainingAttempts(BigInteger.valueOf(activation.getMaxFailedAttempts()));
                     response.setSignatureValid(true);
                     response.setUserId(activation.getUserId());
-                    response.setEncryptedVaultEncryptionKey(BaseEncoding.base64().encode(cKeyBytes));
+                    response.setEncryptedVaultEncryptionKey(Base64.getEncoder().encodeToString(cKeyBytes));
 
                     return response;
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ApplicationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/ApplicationServiceBehavior.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v3;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v3.*;
 import io.getlime.security.powerauth.app.server.database.RepositoryCatalogue;
 import io.getlime.security.powerauth.app.server.database.model.entity.ApplicationEntity;
@@ -38,6 +37,7 @@ import org.springframework.stereotype.Component;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -178,8 +178,8 @@ public class ApplicationServiceBehavior {
             // Generate the default master key pair
             final MasterKeyPairEntity keyPair = new MasterKeyPairEntity();
             keyPair.setApplication(application);
-            keyPair.setMasterKeyPrivateBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPrivateKeyToBytes(privateKey)));
-            keyPair.setMasterKeyPublicBase64(BaseEncoding.base64().encode(keyConversionUtilities.convertPublicKeyToBytes(publicKey)));
+            keyPair.setMasterKeyPrivateBase64(Base64.getEncoder().encodeToString(keyConversionUtilities.convertPrivateKeyToBytes(privateKey)));
+            keyPair.setMasterKeyPublicBase64(Base64.getEncoder().encodeToString(keyConversionUtilities.convertPublicKeyToBytes(publicKey)));
             keyPair.setTimestampCreated(new Date());
             keyPair.setName(id + " Default Keypair");
             repositoryCatalogue.getMasterKeyPairRepository().save(keyPair);
@@ -189,8 +189,8 @@ public class ApplicationServiceBehavior {
             version.setApplication(application);
             version.setId("default");
             version.setSupported(true);
-            version.setApplicationKey(BaseEncoding.base64().encode(applicationKeyBytes));
-            version.setApplicationSecret(BaseEncoding.base64().encode(applicationSecretBytes));
+            version.setApplicationKey(Base64.getEncoder().encodeToString(applicationKeyBytes));
+            version.setApplicationSecret(Base64.getEncoder().encodeToString(applicationSecretBytes));
             repositoryCatalogue.getApplicationVersionRepository().save(version);
 
             final CreateApplicationResponse response = new CreateApplicationResponse();
@@ -241,8 +241,8 @@ public class ApplicationServiceBehavior {
         version.setApplication(application);
         version.setId(applicationVersionId);
         version.setSupported(true);
-        version.setApplicationKey(BaseEncoding.base64().encode(applicationKeyBytes));
-        version.setApplicationSecret(BaseEncoding.base64().encode(applicationSecretBytes));
+        version.setApplicationKey(Base64.getEncoder().encodeToString(applicationKeyBytes));
+        version.setApplicationSecret(Base64.getEncoder().encodeToString(applicationSecretBytes));
         version = repositoryCatalogue.getApplicationVersionRepository().save(version);
 
         final CreateApplicationVersionResponse response = new CreateApplicationVersionResponse();

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/AsymmetricSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/AsymmetricSignatureServiceBehavior.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v3;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import io.getlime.security.powerauth.app.server.database.repository.ActivationRepository;
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
@@ -35,6 +34,7 @@ import org.springframework.stereotype.Component;
 import java.security.InvalidKeyException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 /**
  * Behavior class implementing the asymmetric (ECDSA) signature validation related processes. The
@@ -75,9 +75,9 @@ public class AsymmetricSignatureServiceBehavior {
                 logger.warn("Activation used when verifying ECDSA signature does not exist, activation ID: {}", activationId);
                 return false;
             }
-            byte[] devicePublicKeyData = BaseEncoding.base64().decode(activation.getDevicePublicKeyBase64());
+            byte[] devicePublicKeyData = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
             PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(devicePublicKeyData);
-            return signatureUtils.validateECDSASignature(BaseEncoding.base64().decode(data), BaseEncoding.base64().decode(signature), devicePublicKey);
+            return signatureUtils.validateECDSASignature(Base64.getDecoder().decode(data), Base64.getDecoder().decode(signature), devicePublicKey);
         } catch (InvalidKeyException | InvalidKeySpecException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v3;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.core.audit.base.Audit;
 import com.wultra.core.audit.base.model.AuditDetail;
 import com.wultra.core.audit.base.model.AuditLevel;
@@ -35,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.xml.datatype.DatatypeConfigurationException;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 
@@ -148,7 +148,7 @@ public class AuditingServiceBehavior {
     public void logSignatureAuditRecord(ActivationRecordEntity activation, SignatureData signatureData, SignatureType signatureType, Boolean valid, Integer version, String note, Date currentTimestamp) {
 
         final String additionalInfo = keyValueMapConverter.toString(signatureData.getAdditionalInfo());
-        final String data = BaseEncoding.base64().encode(signatureData.getData());
+        final String data = Base64.getEncoder().encodeToString(signatureData.getData());
 
         // Audit the signature
         final SignatureEntity signatureAuditRecord = new SignatureEntity();

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/SignatureSharedServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/SignatureSharedServiceBehavior.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks.v3;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v3.KeyValueMap;
 import com.wultra.security.powerauth.client.v3.SignatureType;
 import io.getlime.security.powerauth.app.server.configuration.PowerAuthServiceConfiguration;
@@ -55,6 +54,7 @@ import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -275,8 +275,8 @@ public class SignatureSharedServiceBehavior {
         final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activation.getActivationId());
 
         // Decode the keys to byte[]
-        final byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(serverPrivateKeyBase64);
-        final byte[] devicePublicKeyBytes = BaseEncoding.base64().decode(activation.getDevicePublicKeyBase64());
+        final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
+        final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
         final PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(serverPrivateKeyBytes);
         final PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(devicePublicKeyBytes);
 
@@ -301,7 +301,7 @@ public class SignatureSharedServiceBehavior {
         final HashBasedCounter hashBasedCounter = new HashBasedCounter();
         // Get counter data from activation for version 3
         if (signatureVersion == 3) {
-            ctrHash = BaseEncoding.base64().decode(activation.getCtrDataBase64());
+            ctrHash = Base64.getDecoder().decode(activation.getCtrDataBase64());
         }
         // Signature type which was used to verify signature succesfully
         SignatureType usedSignatureType = null;
@@ -422,7 +422,7 @@ public class SignatureSharedServiceBehavior {
 
         if (verificationResponse.getForcedSignatureVersion() == 3) {
             // Set the ctrData to next valid ctrData value
-            activation.setCtrDataBase64(BaseEncoding.base64().encode(verificationResponse.getCtrDataNext()));
+            activation.setCtrDataBase64(Base64.getEncoder().encodeToString(verificationResponse.getCtrDataNext()));
         }
 
         // Set the activation record counter to next valid counter value

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server.service.v3;
 
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.*;
 import com.wultra.security.powerauth.client.model.validator.*;
@@ -308,10 +307,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             final String activationCode = request.getActivationCode();
             final String applicationKey = request.getApplicationKey();
             final Boolean shouldGenerateRecoveryCodes = request.isGenerateRecoveryCodes();
-            final byte[] ephemeralPublicKey = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
-            final byte[] mac = BaseEncoding.base64().decode(request.getMac());
-            final byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
-            final byte[] nonce = request.getNonce() != null ? BaseEncoding.base64().decode(request.getNonce()) : null;
+            final byte[] ephemeralPublicKey = Base64.getDecoder().decode(request.getEphemeralPublicKey());
+            final byte[] mac = Base64.getDecoder().decode(request.getMac());
+            final byte[] encryptedData = Base64.getDecoder().decode(request.getEncryptedData());
+            final byte[] nonce = request.getNonce() != null ? Base64.getDecoder().decode(request.getNonce()) : null;
             final EciesCryptogram cryptogram = new EciesCryptogram(ephemeralPublicKey, mac, encryptedData, nonce);
             logger.info("PrepareActivationRequest received, activation code: {}", activationCode);
             final PrepareActivationResponse response = behavior.getActivationServiceBehavior().prepareActivation(activationCode, applicationKey, shouldGenerateRecoveryCodes, cryptogram, keyConvertor);
@@ -345,10 +344,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             final Long maxFailedCount = request.getMaxFailureCount();
             final String applicationKey = request.getApplicationKey();
             final String activationOtp = request.getActivationOtp();
-            final byte[] ephemeralPublicKey = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
-            final byte[] mac = BaseEncoding.base64().decode(request.getMac());
-            final byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
-            final byte[] nonce = request.getNonce() != null ? BaseEncoding.base64().decode(request.getNonce()) : null;
+            final byte[] ephemeralPublicKey = Base64.getDecoder().decode(request.getEphemeralPublicKey());
+            final byte[] mac = Base64.getDecoder().decode(request.getMac());
+            final byte[] encryptedData = Base64.getDecoder().decode(request.getEncryptedData());
+            final byte[] nonce = request.getNonce() != null ? Base64.getDecoder().decode(request.getNonce()) : null;
             final EciesCryptogram cryptogram = new EciesCryptogram(ephemeralPublicKey, mac, encryptedData, nonce);
             logger.info("CreateActivationRequest received, user ID: {}", userId);
             final CreateActivationResponse response = behavior.getActivationServiceBehavior().createActivation(
@@ -673,10 +672,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             final SignatureType signatureType = request.getSignatureType();
             final String signatureVersion = request.getSignatureVersion();
             final String signedData = request.getSignedData();
-            byte[] ephemeralPublicKey = BaseEncoding.base64().decode(request.getEphemeralPublicKey());
-            byte[] encryptedData = BaseEncoding.base64().decode(request.getEncryptedData());
-            byte[] mac = BaseEncoding.base64().decode(request.getMac());
-            byte[] nonce = request.getNonce() != null ? BaseEncoding.base64().decode(request.getNonce()) : null;
+            byte[] ephemeralPublicKey = Base64.getDecoder().decode(request.getEphemeralPublicKey());
+            byte[] encryptedData = Base64.getDecoder().decode(request.getEncryptedData());
+            byte[] mac = Base64.getDecoder().decode(request.getMac());
+            byte[] nonce = request.getNonce() != null ? Base64.getDecoder().decode(request.getNonce()) : null;
 
             logger.info("VaultUnlockRequest received, activation ID: {}", activationId);
 

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/RecoveryPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/RecoveryPrivateKeyConverterTest.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.app.server.converter.v3.RecoveryPrivateKeyConverter;
 import io.getlime.security.powerauth.app.server.database.model.EncryptionMode;
 import io.getlime.security.powerauth.app.server.database.model.RecoveryPrivateKey;
@@ -27,6 +26,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,7 +59,7 @@ public class RecoveryPrivateKeyConverterTest {
 
     @Test
     public void testEncryptionAndDecryptionSuccess() throws Exception {
-        byte[] recoveryPrivateKeyBytes = BaseEncoding.base64().decode(RECOVERY_PRIVATE_KEY_PLAIN);
+        byte[] recoveryPrivateKeyBytes = Base64.getDecoder().decode(RECOVERY_PRIVATE_KEY_PLAIN);
         RecoveryPrivateKey recoveryPrivateKeyEncrypted = recoveryPrivateKeyConverter.toDBValue(recoveryPrivateKeyBytes,1);
         String recoveryPrivateKeyActual = recoveryPrivateKeyConverter.fromDBValue(recoveryPrivateKeyEncrypted, 1);
         assertEquals(RECOVERY_PRIVATE_KEY_PLAIN, recoveryPrivateKeyActual);
@@ -67,7 +68,7 @@ public class RecoveryPrivateKeyConverterTest {
     @Test
     public void testEncryptionAndDecryptionDifferentApplicationFail() {
         assertThrows(GenericServiceException.class, ()-> {
-            byte[] recoveryPrivateKeyBytes = BaseEncoding.base64().decode(RECOVERY_PRIVATE_KEY_PLAIN);
+            byte[] recoveryPrivateKeyBytes = Base64.getDecoder().decode(RECOVERY_PRIVATE_KEY_PLAIN);
             RecoveryPrivateKey recoveryPrivateKeyEncrypted = recoveryPrivateKeyConverter.toDBValue(recoveryPrivateKeyBytes, 1);
             recoveryPrivateKeyConverter.fromDBValue(recoveryPrivateKeyEncrypted, 2);
         });

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/ServerPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/ServerPrivateKeyConverterTest.java
@@ -17,7 +17,6 @@
  */
 package io.getlime.security.powerauth.app.server;
 
-import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.app.server.converter.v3.ServerPrivateKeyConverter;
 import io.getlime.security.powerauth.app.server.database.model.EncryptionMode;
 import io.getlime.security.powerauth.app.server.database.model.ServerPrivateKey;
@@ -27,6 +26,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,7 +59,7 @@ public class ServerPrivateKeyConverterTest {
 
     @Test
     public void testEncryptionAndDecryptionSuccess() throws Exception {
-        byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(SERVER_PRIVATE_KEY_PLAIN);
+        byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(SERVER_PRIVATE_KEY_PLAIN);
         ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes,"test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         String serverPrivateKeyActual = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         assertEquals(SERVER_PRIVATE_KEY_PLAIN, serverPrivateKeyActual);
@@ -67,7 +68,7 @@ public class ServerPrivateKeyConverterTest {
     @Test
     public void testEncryptionAndDecryptionDifferentUserFail() {
         assertThrows(GenericServiceException.class, ()-> {
-            byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(SERVER_PRIVATE_KEY_PLAIN);
+            byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(SERVER_PRIVATE_KEY_PLAIN);
             ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
             serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, "test2", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         });
@@ -76,7 +77,7 @@ public class ServerPrivateKeyConverterTest {
     @Test
     public void testEncryptionAndDecryptionDifferentActivationFailServerPrivateKeyConverter() {
         assertThrows(GenericServiceException.class, ()-> {
-            byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(SERVER_PRIVATE_KEY_PLAIN);
+            byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(SERVER_PRIVATE_KEY_PLAIN);
             ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
             serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, "test", "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         });

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -1,7 +1,6 @@
 package io.getlime.security.powerauth.app.server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.BaseEncoding;
 import com.wultra.security.powerauth.client.v3.*;
 import io.getlime.security.powerauth.app.server.converter.v3.XMLGregorianCalendarConverter;
 import io.getlime.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
@@ -25,10 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
@@ -74,13 +70,13 @@ public class VerifySignatureConcurrencyTest {
 
         ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName("test_activation");
-        requestL2.setDevicePublicKey(BaseEncoding.base64().encode(publicKeyBytes));
+        requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
 
         GetApplicationDetailRequest detailRequest = new GetApplicationDetailRequest();
         detailRequest.setApplicationId(createApplicationResponse.getApplicationId());
         GetApplicationDetailResponse detailResponse = powerAuthService.getApplicationDetail(detailRequest);
 
-        ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(BaseEncoding.base64().decode(detailResponse.getMasterPublicKey()));
+        ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
 
         EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey, createApplicationVersionResponse.getApplicationSecret().getBytes(StandardCharsets.UTF_8), EciesSharedInfo1.ACTIVATION_LAYER_2);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -93,10 +89,10 @@ public class VerifySignatureConcurrencyTest {
         createActivationRequest.setTimestampActivationExpire(XMLGregorianCalendarConverter.convertFrom(expiration.getTime()));
         createActivationRequest.setMaxFailureCount(5L);
         createActivationRequest.setApplicationKey(createApplicationVersionResponse.getApplicationKey());
-        createActivationRequest.setEncryptedData(BaseEncoding.base64().encode(eciesCryptogram.getEncryptedData()));
-        createActivationRequest.setMac(BaseEncoding.base64().encode(eciesCryptogram.getMac()));
-        createActivationRequest.setEphemeralPublicKey(BaseEncoding.base64().encode(eciesCryptogram.getEphemeralPublicKey()));
-        createActivationRequest.setNonce(BaseEncoding.base64().encode(eciesCryptogram.getNonce()));
+        createActivationRequest.setEncryptedData(Base64.getEncoder().encodeToString(eciesCryptogram.getEncryptedData()));
+        createActivationRequest.setMac(Base64.getEncoder().encodeToString(eciesCryptogram.getMac()));
+        createActivationRequest.setEphemeralPublicKey(Base64.getEncoder().encodeToString(eciesCryptogram.getEphemeralPublicKey()));
+        createActivationRequest.setNonce(Base64.getEncoder().encodeToString(eciesCryptogram.getNonce()));
         CreateActivationResponse createActivationResponse = powerAuthService.createActivation(createActivationRequest);
 
         // Commit activation


### PR DESCRIPTION
Use `java.util.Base64` instead of `com.google.common.io.BaseEncoding#base64()`.

See https://rules.sonarsource.com/java/tag/java8/RSPEC-4738