### PR TITLE
Broken ECIES 3.2

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/ConfirmRecoveryCodeResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/ConfirmRecoveryCodeResponse.java
@@ -33,7 +33,6 @@ public class ConfirmRecoveryCodeResponse {
     private String userId;
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     @ToString.Exclude
     private String nonce;
     private Long timestamp;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/CreateActivationResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/CreateActivationResponse.java
@@ -35,7 +35,6 @@ public class CreateActivationResponse {
     private String applicationId;
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     @ToString.Exclude
     private String nonce;
     private Long timestamp;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/CreateTokenResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/CreateTokenResponse.java
@@ -31,7 +31,6 @@ public class CreateTokenResponse {
 
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     @ToString.Exclude
     private String nonce;
     private Long timestamp;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/PrepareActivationResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/PrepareActivationResponse.java
@@ -35,7 +35,6 @@ public class PrepareActivationResponse {
     private String applicationId;
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     @ToString.Exclude
     private String nonce;
     private Long timestamp;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/RecoveryCodeActivationResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/RecoveryCodeActivationResponse.java
@@ -35,7 +35,6 @@ public class RecoveryCodeActivationResponse {
     private String applicationId;
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     @ToString.Exclude
     private String nonce;
     private Long timestamp;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/StartUpgradeResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/StartUpgradeResponse.java
@@ -31,7 +31,6 @@ public class StartUpgradeResponse {
 
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     @ToString.Exclude
     private String nonce;
     private Long timestamp;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/VaultUnlockResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/VaultUnlockResponse.java
@@ -31,7 +31,6 @@ public class VaultUnlockResponse {
 
     private String encryptedData;
     private String mac;
-    private String ephemeralPublicKey;
     private boolean signatureValid;
     @ToString.Exclude
     private String nonce;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -992,7 +992,6 @@ public class ActivationServiceBehavior {
             final EciesPayload responseEciesPayload = encryptorResponse.encrypt(responseData, parametersResponse);
             final String encryptedData = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEncryptedData());
             final String mac = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getMac());
-            final String ephemeralPublicKey = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEphemeralPublicKey());
 
             // Persist activation report and notify listeners
             activationHistoryServiceBehavior.saveActivationAndLogChange(activation);
@@ -1005,7 +1004,6 @@ public class ActivationServiceBehavior {
             encryptedResponse.setApplicationId(applicationId);
             encryptedResponse.setEncryptedData(encryptedData);
             encryptedResponse.setMac(mac);
-            encryptedResponse.setEphemeralPublicKey(ephemeralPublicKey);
             encryptedResponse.setNonce(nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
             encryptedResponse.setTimestamp(timestampResponse);
             encryptedResponse.setActivationStatus(activationStatusConverter.convert(activationStatus));
@@ -1205,7 +1203,6 @@ public class ActivationServiceBehavior {
             final EciesPayload responseEciesPayload = encryptorResponse.encrypt(responseData, parametersResponse);
             final String encryptedData = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEncryptedData());
             final String mac = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getMac());
-            final String ephemeralPublicKey = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEphemeralPublicKey());
 
             // Generate encrypted response
             final CreateActivationResponse encryptedResponse = new CreateActivationResponse();
@@ -1214,7 +1211,6 @@ public class ActivationServiceBehavior {
             encryptedResponse.setApplicationId(applicationId);
             encryptedResponse.setEncryptedData(encryptedData);
             encryptedResponse.setMac(mac);
-            encryptedResponse.setEphemeralPublicKey(ephemeralPublicKey);
             encryptedResponse.setNonce(nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
             encryptedResponse.setTimestamp(timestampResponse);
             encryptedResponse.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));
@@ -1879,7 +1875,6 @@ public class ActivationServiceBehavior {
             final EciesPayload responseEciesPayload = encryptorResponse.encrypt(responseData, parametersResponse);
             final String encryptedDataResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEncryptedData());
             final String macResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getMac());
-            final String ephemeralPublicKeyResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEphemeralPublicKey());
 
             final RecoveryCodeActivationResponse encryptedResponse = new RecoveryCodeActivationResponse();
             encryptedResponse.setActivationId(activation.getActivationId());
@@ -1887,7 +1882,6 @@ public class ActivationServiceBehavior {
             encryptedResponse.setApplicationId(applicationId);
             encryptedResponse.setEncryptedData(encryptedDataResponse);
             encryptedResponse.setMac(macResponse);
-            encryptedResponse.setEphemeralPublicKey(ephemeralPublicKeyResponse);
             encryptedResponse.setNonce(nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
             encryptedResponse.setTimestamp(timestampResponse);
             encryptedResponse.setActivationStatus(activationStatusConverter.convert(activation.getActivationStatus()));

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -983,7 +983,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final byte[] nonceBytesResponse = ("3.2".equals(version) || "3.1".equals(version)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
             final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.APPLICATION_SCOPE,
@@ -1195,7 +1195,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final byte[] nonceBytesResponse = ("3.2".equals(version) || "3.1".equals(version)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
             final byte[] associatedData = "3.2".equals(version) ? EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, version, applicationKey, null) : null;
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(associatedData).timestamp(timestampResponse).build();
@@ -1870,7 +1870,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final byte[] nonceBytesResponse = ("3.2".equals(version) || "3.1".equals(version)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
             final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.APPLICATION_SCOPE,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
@@ -417,7 +417,6 @@ public class RecoveryServiceBehavior {
             response.setUserId(recoveryCodeEntity.getUserId());
             response.setEncryptedData(encryptedDataResponse);
             response.setMac(macResponse);
-            response.setEphemeralPublicKey(ephemeralPublicKey);
             response.setNonce(nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
             response.setTimestamp(timestampResponse);
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
@@ -400,7 +400,7 @@ public class RecoveryServiceBehavior {
             final byte[] responseBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response using ECIES encryptor
-            final byte[] nonceBytesResponse = ("3.2".equals(version) || "3.1".equals(version)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
 
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(associatedData).timestamp(timestampResponse).build();

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -147,7 +147,6 @@ public class TokenBehavior {
         final CreateTokenResponse response = new CreateTokenResponse();
         response.setMac(Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getMac()));
         response.setEncryptedData(Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEncryptedData()));
-        response.setEphemeralPublicKey(Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEphemeralPublicKey()));
         response.setNonce(responseEciesPayload.getParameters().getNonce() != null ? Base64.getEncoder().encodeToString(responseEciesPayload.getParameters().getNonce()) : null);
         response.setTimestamp(responseEciesPayload.getParameters().getTimestamp());
         return response;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -248,7 +248,7 @@ public class TokenBehavior {
             final byte[] tokenBytes = objectMapper.writeValueAsBytes(tokenInfo);
 
             // Encrypt response using previously created ECIES decryptor
-            final byte[] nonceBytesResponse = ("3.1".equals(version) || "3.2".equals(version)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
             final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.ACTIVATION_SCOPE,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -226,7 +226,7 @@ public class UpgradeServiceBehavior {
             // Encrypt response payload and return it
             final byte[] payloadBytes = objectMapper.writeValueAsBytes(payload);
 
-            final byte[] nonceBytesResponse = ("3.2".equals(version) || "3.1".equals(version)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
             final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.ACTIVATION_SCOPE,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -236,7 +236,6 @@ public class UpgradeServiceBehavior {
             final StartUpgradeResponse response = new StartUpgradeResponse();
             response.setEncryptedData(Base64.getEncoder().encodeToString(payloadResponse.getCryptogram().getEncryptedData()));
             response.setMac(Base64.getEncoder().encodeToString(payloadResponse.getCryptogram().getMac()));
-            response.setEphemeralPublicKey(Base64.getEncoder().encodeToString(payloadResponse.getCryptogram().getEphemeralPublicKey()));
             response.setNonce(nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
             response.setTimestamp(timestampResponse);
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -225,7 +225,7 @@ public class VaultUnlockServiceBehavior {
             final byte[] reponsePayloadBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response payload
-            final byte[] nonceBytesResponse = ("3.2".equals(signatureVersion) || "3.1".equals(signatureVersion)) ? keyGenerator.generateRandomBytes(16) : null;
+            final byte[] nonceBytesResponse = "3.2".equals(signatureVersion) ? keyGenerator.generateRandomBytes(16) : null;
             final Long timestampResponse = "3.2".equals(signatureVersion) ? new Date().getTime() : null;
             final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
             final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.ACTIVATION_SCOPE,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -234,13 +234,11 @@ public class VaultUnlockServiceBehavior {
             final EciesPayload responseEciesPayload = encryptorResponse.encrypt(reponsePayloadBytes, parametersResponse);
             final String dataResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEncryptedData());
             final String macResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getMac());
-            final String ephemeralPublicKeyResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEphemeralPublicKey());
 
             // Return vault unlock response, set signature validity
             final VaultUnlockResponse response = new VaultUnlockResponse();
             response.setEncryptedData(dataResponse);
             response.setMac(macResponse);
-            response.setEphemeralPublicKey(ephemeralPublicKeyResponse);
             response.setNonce(nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
             response.setTimestamp(timestampResponse);
             response.setSignatureValid(signatureResponse.isSignatureValid());


### PR DESCRIPTION
This PR fixes two major problems in ECIES 3.2 implementation:

- Do not use nonce in encrypted response (#950)
- Do not return `ephemeralPublicKey` in encrypted responses (#938)