### PR TITLE
Use general encryptor for E2EE

### DIFF
--- a/docs/PowerAuth-Server-1.5.0.md
+++ b/docs/PowerAuth-Server-1.5.0.md
@@ -127,3 +127,52 @@ Since version `1.5.0`, MySQL database is not supported anymore.
 
 PostgreSQL JDBC driver is already included in the WAR file.
 Oracle JDBC driver remains optional and must be added to your deployment if desired.
+
+## Configuration properties
+
+In previous versions of PowerAuth Server, time-based properties were represented as a long value, specifying the
+duration in milliseconds. From version `1.5.0` onwards, we've transitioned to using `java.time.Duration` for these
+durations. Consequently, these properties must now be specified in the ISO-8601 duration format (`PnDTnHnMn.nS`),
+providing a more human-readable format and eliminating potential misunderstandings with units.
+
+Consider the following property as an example:
+
+```properties
+powerauth.service.crypto.activationValidityInMilliseconds=300000
+```
+
+Should now be defined as:
+
+```properties
+powerauth.service.crypto.activationValidityTime=PT5M
+```
+
+The ISO-8601 duration format is more explicit about the units of time being used, making it easier to understand and
+adjust the configuration.
+
+Remember to check all your time-based properties to this new format when migrating to PowerAuth Server version `1.5.0`
+or newer. All the affected properties are:
+
+- `powerauth.service.crypto.activationValidityTime`
+- `powerauth.service.crypto.requestExpirationTime`
+- `powerauth.service.http.connection.timeout`
+- `powerauth.service.token.timestamp.validity`
+- `powerauth.service.token.timestamp.forward.validity`
+- `powerauth.service.scheduled.job.operationCleanup`
+- `powerauth.service.scheduled.job.activationsCleanup`
+- `powerauth.service.scheduled.job.activationsCleanup.lookBack`
+- `powerauth.service.scheduled.job.uniqueValueCleanup`
+
+## RESTful integration Changes
+
+PowerAuth restful integration libraries in version `1.5.0` have the following important changes:
+
+- `@PowerAuthEncryption` annotation now use `enum EncryptionScope` scope parameter provided by this library instead of low level `enum EciesScope`:
+  - Please update your imports to `import io.getlime.security.powerauth.rest.api.spring.encryption.EncryptionScope;`
+  - Replace usage of `EciesScope` with `EncryptionScope`, for example:
+    ```java
+    @PowerAuthEncryption(scope = EncryptionScope.APPLICATION_SCOPE)
+    ```
+- `EciesEncryptionContext` class is replaced with `EncryptionContext`
+  - Please update your imports to `import io.getlime.security.powerauth.rest.api.spring.encryption.EncryptionContext;`
+  - Replace usage of `EciesEncryptionContext` to `EncryptionContext`

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/PowerAuthService.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/PowerAuthService.java
@@ -310,6 +310,7 @@ public class PowerAuthService {
             final String applicationKey = request.getApplicationKey();
             final boolean shouldGenerateRecoveryCodes = request.isGenerateRecoveryCodes();
             final String protocolVersion = request.getProtocolVersion();
+            // Build encrypted request
             final EncryptedRequest encryptedRequest = new EncryptedRequest(
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -698,6 +699,7 @@ public class PowerAuthService {
             final SignatureType signatureType = request.getSignatureType();
             final String signatureVersion = request.getSignatureVersion();
             final String signedData = request.getSignedData();
+            // Build encrypted request
             final EncryptedRequest encryptedRequest = new EncryptedRequest(
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1108,7 +1110,7 @@ public class PowerAuthService {
 
     @Transactional
     public CreateTokenResponse createToken(CreateTokenRequest request) throws GenericServiceException {
-        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getEncryptedData() == null || request.getMac() == null) {
+        if (request.getActivationId() == null || request.getApplicationKey() == null) {
             logger.warn("Invalid request parameters in method createToken");
             // Rollback is not required, error occurs before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
@@ -1214,7 +1216,7 @@ public class PowerAuthService {
 
     @Transactional
     public StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws GenericServiceException {
-        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null || request.getEncryptedData() == null || request.getMac() == null) {
+        if (request.getActivationId() == null || request.getApplicationKey() == null) {
             logger.warn("Invalid request parameters in method startUpgrade");
             // Rollback is not required, error occurs before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
@@ -1286,8 +1288,7 @@ public class PowerAuthService {
 
     @Transactional
     public ConfirmRecoveryCodeResponse confirmRecoveryCode(ConfirmRecoveryCodeRequest request) throws GenericServiceException {
-        if (request.getActivationId() == null || request.getApplicationKey() == null || request.getEphemeralPublicKey() == null
-                || request.getEncryptedData() == null || request.getMac() == null) {
+        if (request.getActivationId() == null || request.getApplicationKey() == null) {
             logger.warn("Invalid request parameters in method confirmRecoveryCode");
             // Rollback is not required, error occurs before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
@@ -1359,8 +1360,7 @@ public class PowerAuthService {
 
     @Transactional(rollbackFor = {RuntimeException.class, RollbackingServiceException.class})
     public RecoveryCodeActivationResponse createActivationUsingRecoveryCode(RecoveryCodeActivationRequest request) throws GenericServiceException {
-        if (request.getRecoveryCode() == null || request.getPuk() == null || request.getApplicationKey() == null
-            || request.getEphemeralPublicKey() == null || request.getEncryptedData() == null || request.getMac() == null) {
+        if (request.getRecoveryCode() == null || request.getPuk() == null || request.getApplicationKey() == null) {
             logger.warn("Invalid request parameters in method createActivationUsingRecoveryCode");
             // Rollback is not required, error occurs before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
@@ -28,19 +28,20 @@ import io.getlime.security.powerauth.app.server.database.model.entity.Activation
 import io.getlime.security.powerauth.app.server.database.model.entity.ApplicationEntity;
 import io.getlime.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
 import io.getlime.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
+import io.getlime.security.powerauth.app.server.database.model.enumeration.UniqueValueType;
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEnvelopeKey;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesParameters;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.app.server.service.replay.ReplayVerificationService;
+import io.getlime.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
-import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import org.slf4j.Logger;
@@ -48,14 +49,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
 import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
+import java.util.Date;
 
 /**
  * Behavior class implementing the ECIES service logic.
@@ -73,9 +70,10 @@ public class EciesEncryptionBehavior {
     private final RepositoryCatalogue repositoryCatalogue;
     private final LocalizationProvider localizationProvider;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
+    private final ReplayVerificationService replayVerificationService;
 
     // Helper classes
-    private final EciesFactory eciesFactory = new EciesFactory();
+    private final EncryptorFactory encryptorFactory = new EncryptorFactory();
     private final PowerAuthServerKeyFactory powerAuthServerKeyFactory = new PowerAuthServerKeyFactory();
     private final KeyConvertor keyConvertor = new KeyConvertor();
 
@@ -83,10 +81,11 @@ public class EciesEncryptionBehavior {
     private static final Logger logger = LoggerFactory.getLogger(EciesEncryptionBehavior.class);
 
     @Autowired
-    public EciesEncryptionBehavior(RepositoryCatalogue repositoryCatalogue, LocalizationProvider localizationProvider, ServerPrivateKeyConverter serverPrivateKeyConverter) {
+    public EciesEncryptionBehavior(RepositoryCatalogue repositoryCatalogue, LocalizationProvider localizationProvider, ServerPrivateKeyConverter serverPrivateKeyConverter, ReplayVerificationService replayVerificationService) {
         this.repositoryCatalogue = repositoryCatalogue;
         this.localizationProvider = localizationProvider;
         this.serverPrivateKeyConverter = serverPrivateKeyConverter;
+        this.replayVerificationService = replayVerificationService;
     }
 
     /**
@@ -132,6 +131,16 @@ public class EciesEncryptionBehavior {
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
             }
 
+            if (request.getTimestamp() != null) {
+                // Check ECIES request for replay attacks and persist unique value from request
+                replayVerificationService.checkAndPersistUniqueValue(
+                        UniqueValueType.ECIES_APPLICATION_SCOPE,
+                        new Date(request.getTimestamp()),
+                        request.getEphemeralPublicKey(),
+                        request.getNonce(),
+                        null);
+            }
+
             // Get master private key
             final ApplicationEntity application = applicationVersion.getApplication();
             final String applicationId = application.getId();
@@ -145,42 +154,35 @@ public class EciesEncryptionBehavior {
             final String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
             final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
 
-            // Get application secret
-            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+            // Build encryptor to derive shared info
+            final ServerEncryptor encryptor = encryptorFactory.getServerEncryptor(
+                    EncryptorId.APPLICATION_SCOPE_GENERIC,
+                    new EncryptorParameters(request.getProtocolVersion(), applicationVersion.getApplicationKey(), null),
+                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+            );
+            // Calculate secrets for the external encryptor
+            final EncryptorSecrets encryptorSecrets = encryptor.calculateSecretsForExternalEncryptor(
+                    new EncryptedRequest(request.getEphemeralPublicKey(), null, null, request.getNonce(), request.getTimestamp())
+            );
+            if (encryptorSecrets instanceof ServerEncryptorSecrets encryptorSecretsV3) {
+                // ECIES V3.0, V3.1, V3.2
+                final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
+                response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
+                response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
+                return response;
+            }
+            logger.error("Unsupported EncryptorSecrets object");
+            // Rollback is not required, database is not used for writing
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
 
-            final String applicationKey = request.getApplicationKey();
-            final byte[] nonceBytes = request.getNonce() != null ? Base64.getDecoder().decode(request.getNonce()) : null;
-            final String version = request.getProtocolVersion();
-            final Long timestamp = "3.2".equals(version) ? request.getTimestamp() : null;
-            final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, version, applicationKey, null);
-            final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).timestamp(timestamp).associatedData(associatedData).build();
-            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(request.getEphemeralPublicKey());
-            // Get decryptor for the application
-            final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForApplication(
-                    (ECPrivateKey) privateKey, applicationSecret, EciesSharedInfo1.APPLICATION_SCOPE_GENERIC,
-                    eciesParameters, ephemeralPublicKeyBytes);
-
-            // Initialize decryptor with ephemeral public key
-            decryptor.initEnvelopeKey(ephemeralPublicKeyBytes);
-
-            // Extract envelope key and sharedInfo2 parameters to allow decryption on intermediate server
-            final EciesEnvelopeKey envelopeKey = decryptor.getEnvelopeKey();
-            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
-            response.setSecretKey(Base64.getEncoder().encodeToString(envelopeKey.getSecretKey()));
-            response.setSharedInfo2(Base64.getEncoder().encodeToString(decryptor.getSharedInfo2()));
-            return response;
         } catch (InvalidKeySpecException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing
             throw localizationProvider.buildExceptionForCode(ServiceError.INCORRECT_MASTER_SERVER_KEYPAIR_PRIVATE);
-        } catch (EciesException ex) {
+        } catch (EncryptorException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        } catch (GenericCryptoException ex) {
-            logger.error(ex.getMessage(), ex);
-            // Rollback is not required, database is not used for writing
-            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
         } catch (CryptoProviderException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing
@@ -201,7 +203,6 @@ public class EciesEncryptionBehavior {
             // Rollback is not required, database is not used for writing
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
         }
-
         try {
             // Lookup the activation
             final ActivationRecordEntity activation = repositoryCatalogue.getActivationRepository().findActivationWithoutLock(request.getActivationId());
@@ -209,6 +210,16 @@ public class EciesEncryptionBehavior {
                 logger.info("Activation does not exist, activation ID: {}", request.getActivationId());
                 // Rollback is not required, database is not used for writing
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+            }
+
+            if (request.getTimestamp() != null) {
+                // Check ECIES request for replay attacks and persist unique value from request
+                replayVerificationService.checkAndPersistUniqueValue(
+                        UniqueValueType.ECIES_APPLICATION_SCOPE,
+                        new Date(request.getTimestamp()),
+                        request.getEphemeralPublicKey(),
+                        request.getNonce(),
+                        activation.getActivationId());
             }
 
             // Check if the activation is in correct state
@@ -241,53 +252,39 @@ public class EciesEncryptionBehavior {
             final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
             final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
 
-            // Get application secret and transport key used in sharedInfo2 parameter of ECIES
-            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
-            final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
-            final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
-            final byte[] transportKeyBytes = keyConversion.convertSharedSecretKeyToBytes(transportKey);
+            // Build encryptor to derive shared info
+            final ServerEncryptor encryptor = encryptorFactory.getServerEncryptor(
+                    EncryptorId.APPLICATION_SCOPE_GENERIC,
+                    new EncryptorParameters(request.getProtocolVersion(), applicationVersion.getApplicationKey(), activation.getActivationId()),
+                    new ServerEncryptorSecrets(serverPrivateKey, applicationVersion.getApplicationSecret())
+            );
+            // Calculate secrets for the external encryptor. The request object may not contain encrypted data and mac.
+            final EncryptorSecrets encryptorSecrets = encryptor.calculateSecretsForExternalEncryptor(
+                    new EncryptedRequest(request.getEphemeralPublicKey(), null, null, request.getNonce(), request.getTimestamp())
+            );
+            if (encryptorSecrets instanceof ServerEncryptorSecrets encryptorSecretsV3) {
+                // ECIES V3.0, V3.1, V3.2
+                final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
+                response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
+                response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
+                return response;
+            }
+            logger.error("Unsupported EncryptorSecrets object");
+            // Rollback is not required, database is not used for writing
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
 
-            final Long timestamp = request.getTimestamp();
-            final String version = request.getProtocolVersion();
-            final String applicationKey = request.getApplicationKey();
-            final String activationId = request.getActivationId();
-            final byte[] nonceBytes = request.getNonce() != null ? Base64.getDecoder().decode(request.getNonce()) : null;
-            final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, version, applicationKey, activationId);
-            final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).timestamp(timestamp).associatedData(associatedData).build();
-            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(request.getEphemeralPublicKey());
-
-            // Get decryptor for the activation
-            final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForActivation(
-                    (ECPrivateKey) serverPrivateKey, applicationSecret, transportKeyBytes, EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC,
-                    eciesParameters, ephemeralPublicKeyBytes);
-
-            // Initialize decryptor with ephemeral public key
-            decryptor.initEnvelopeKey(ephemeralPublicKeyBytes);
-
-            // Extract envelope key and sharedInfo2 parameters to allow decryption on intermediate server
-            final EciesEnvelopeKey envelopeKey = decryptor.getEnvelopeKey();
-            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
-            response.setSecretKey(Base64.getEncoder().encodeToString(envelopeKey.getSecretKey()));
-            response.setSharedInfo2(Base64.getEncoder().encodeToString(decryptor.getSharedInfo2()));
-            return response;
-        } catch (InvalidKeyException | InvalidKeySpecException ex) {
+        } catch (InvalidKeySpecException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
-        } catch (EciesException ex) {
+        } catch (EncryptorException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        } catch (GenericCryptoException ex) {
-            logger.error(ex.getMessage(), ex);
-            // Rollback is not required, database is not used for writing
-            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
         } catch (CryptoProviderException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, database is not used for writing
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_CRYPTO_PROVIDER);
         }
     }
-
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
@@ -37,17 +37,19 @@ import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvide
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.request.ConfirmRecoveryRequestPayload;
 import io.getlime.security.powerauth.app.server.service.model.response.ConfirmRecoveryResponsePayload;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.*;
+import io.getlime.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
 import io.getlime.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.RecoveryInfo;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import io.getlime.security.powerauth.crypto.lib.util.PasswordHash;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
@@ -63,7 +65,6 @@ import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.*;
 
@@ -86,12 +87,12 @@ public class RecoveryServiceBehavior {
     private final RepositoryCatalogue repositoryCatalogue;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
     private final RecoveryPrivateKeyConverter recoveryPrivateKeyConverter;
-    private final ReplayVerificationService eciesreplayPersistenceService;
+    private final ReplayVerificationService replayVerificationService;
 
     // Business logic implementation classes
     private final PowerAuthServerKeyFactory powerAuthServerKeyFactory = new PowerAuthServerKeyFactory();
     private final KeyGenerator keyGenerator = new KeyGenerator();
-    private final EciesFactory eciesFactory = new EciesFactory();
+    private final EncryptorFactory encryptorFactory = new EncryptorFactory();
 
     // Helper classes
     private final ObjectMapper objectMapper;
@@ -105,13 +106,13 @@ public class RecoveryServiceBehavior {
     public RecoveryServiceBehavior(LocalizationProvider localizationProvider,
                                    PowerAuthServiceConfiguration powerAuthServiceConfiguration, RepositoryCatalogue repositoryCatalogue,
                                    ServerPrivateKeyConverter serverPrivateKeyConverter, RecoveryPrivateKeyConverter recoveryPrivateKeyConverter,
-                                   ReplayVerificationService eciesreplayPersistenceService, ObjectMapper objectMapper, RecoveryPukConverter recoveryPukConverter) {
+                                   ReplayVerificationService replayVerificationService, ObjectMapper objectMapper, RecoveryPukConverter recoveryPukConverter) {
         this.localizationProvider = localizationProvider;
         this.powerAuthServiceConfiguration = powerAuthServiceConfiguration;
         this.repositoryCatalogue = repositoryCatalogue;
         this.serverPrivateKeyConverter = serverPrivateKeyConverter;
         this.recoveryPrivateKeyConverter = recoveryPrivateKeyConverter;
-        this.eciesreplayPersistenceService = eciesreplayPersistenceService;
+        this.replayVerificationService = replayVerificationService;
         this.objectMapper = objectMapper;
         this.recoveryPukConverter = recoveryPukConverter;
     }
@@ -278,11 +279,6 @@ public class RecoveryServiceBehavior {
         try {
             final String activationId = request.getActivationId();
             final String applicationKey = request.getApplicationKey();
-            final String ephemeralPublicKey = request.getEphemeralPublicKey();
-            final String encryptedData = request.getEncryptedData();
-            final String mac = request.getMac();
-            final String nonceRequest = request.getNonce();
-
             final RecoveryCodeRepository recoveryCodeRepository = repositoryCatalogue.getRecoveryCodeRepository();
             final RecoveryConfigRepository recoveryConfigRepository = repositoryCatalogue.getRecoveryConfigRepository();
 
@@ -292,6 +288,20 @@ public class RecoveryServiceBehavior {
                 logger.warn("Activation not found, activation ID: {}", activationId);
                 // Rollback is not required, error occurs before writing to database
                 throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+            }
+
+            // Build and validate encrypted request
+            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+                    request.getEphemeralPublicKey(),
+                    request.getEncryptedData(),
+                    request.getMac(),
+                    request.getNonce(),
+                    request.getTimestamp()
+            );
+            if (!encryptorFactory.getRequestResponseValidator(request.getProtocolVersion()).validateEncryptedRequest(encryptedRequest)) {
+                logger.warn("Invalid encrypted request: {}", activationId);
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
             }
 
             // Check whether activation recovery is enabled
@@ -319,38 +329,30 @@ public class RecoveryServiceBehavior {
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
             final ApplicationVersionEntity applicationVersion = repositoryCatalogue.getApplicationVersionRepository().findByApplicationKey(applicationKey);
-            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
+
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
             final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConversion.convertSharedSecretKeyToBytes(transportKey);
 
-            // Get decryptor for the activation
-            final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(ephemeralPublicKey);
-            final byte[] nonceBytesRequest = nonceRequest != null ? Base64.getDecoder().decode(nonceRequest) : null;
-            final String version = request.getProtocolVersion();
-            final Long timestampRequest = "3.2".equals(version) ? request.getTimestamp() : null;
-            final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, version, applicationKey, activationId);
-            // Decrypt request data
-            final byte[] encryptedDataBytes = Base64.getDecoder().decode(encryptedData);
-            final byte[] macBytes = Base64.getDecoder().decode(mac);
-            final EciesCryptogram cryptogramRequest = EciesCryptogram.builder().ephemeralPublicKey(ephemeralPublicKeyBytes).mac(macBytes).encryptedData(encryptedDataBytes).build();
-            final EciesParameters parametersRequest = EciesParameters.builder().nonce(nonceBytesRequest).associatedData(associatedData).timestamp(timestampRequest).build();
-            final EciesPayload payloadRequest = new EciesPayload(cryptogramRequest, parametersRequest);
-            final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForActivation((ECPrivateKey) serverPrivateKey,
-                    applicationSecret, transportKeyBytes, EciesSharedInfo1.CONFIRM_RECOVERY_CODE, parametersRequest, ephemeralPublicKeyBytes);
-
             // Check ECIES request for replay attacks and persist unique value from request
-            if (request.getTimestamp() != null) {
-                eciesreplayPersistenceService.checkAndPersistUniqueValue(
+            if (encryptedRequest.getTimestamp() != null) {
+                replayVerificationService.checkAndPersistUniqueValue(
                         UniqueValueType.ECIES_ACTIVATION_SCOPE,
                         new Date(request.getTimestamp()),
-                        ephemeralPublicKeyBytes,
-                        nonceBytesRequest,
+                        encryptedRequest.getEphemeralPublicKey(),
+                        encryptedRequest.getNonce(),
                         activationId);
             }
 
-            final byte[] decryptedData = decryptor.decrypt(payloadRequest);
+            // Get server decryptor
+            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+                    EncryptorId.CONFIRM_RECOVERY_CODE,
+                    new EncryptorParameters(request.getProtocolVersion(), applicationKey, activationId),
+                    new ServerEncryptorSecrets(serverPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+            );
+            // Decrypt request data
+            final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
 
             // Convert JSON data to confirm recovery request object
             final ConfirmRecoveryRequestPayload requestPayload = objectMapper.readValue(decryptedData, ConfirmRecoveryRequestPayload.class);
@@ -399,26 +401,17 @@ public class RecoveryServiceBehavior {
             // Convert response payload
             final byte[] responseBytes = objectMapper.writeValueAsBytes(responsePayload);
 
-            // Encrypt response using ECIES encryptor
-            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : nonceBytesRequest;
-            final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
-
-            final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(associatedData).timestamp(timestampResponse).build();
-            final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.ACTIVATION_SCOPE,
-                    decryptor.getEnvelopeKey(), applicationSecret, transportKeyBytes, parametersResponse);
-
-            final EciesPayload eciesResponse = encryptorResponse.encrypt(responseBytes, parametersResponse);
-            final String encryptedDataResponse = Base64.getEncoder().encodeToString(eciesResponse.getCryptogram().getEncryptedData());
-            final String macResponse = Base64.getEncoder().encodeToString(eciesResponse.getCryptogram().getMac());
+            // Encrypt response using server encryptor
+            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseBytes);
 
             // Return response
             final ConfirmRecoveryCodeResponse response = new ConfirmRecoveryCodeResponse();
             response.setActivationId(activationId);
             response.setUserId(recoveryCodeEntity.getUserId());
-            response.setEncryptedData(encryptedDataResponse);
-            response.setMac(macResponse);
-            response.setNonce("3.2".equals(version) ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
-            response.setTimestamp(timestampResponse);
+            response.setEncryptedData(encryptedResponse.getEncryptedData());
+            response.setMac(encryptedResponse.getMac());
+            response.setNonce(encryptedResponse.getNonce());
+            response.setTimestamp(encryptedResponse.getTimestamp());
 
             // Confirm recovery code and persist it
             if (inCreatedState) {
@@ -433,7 +426,7 @@ public class RecoveryServiceBehavior {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, cryptography errors can only occur before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
-        } catch (EciesException | IOException ex) {
+        } catch (EncryptorException | IOException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, cryptography errors can only occur before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -37,16 +37,17 @@ import io.getlime.security.powerauth.app.server.service.exceptions.GenericServic
 import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.response.UpgradeResponsePayload;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.*;
+import io.getlime.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
 import io.getlime.security.powerauth.crypto.lib.generator.HashBasedCounter;
-import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import org.slf4j.Logger;
@@ -55,11 +56,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 import java.util.Date;
@@ -75,15 +74,14 @@ public class UpgradeServiceBehavior {
     private final RepositoryCatalogue repositoryCatalogue;
     private final LocalizationProvider localizationProvider;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
-    private final ReplayVerificationService eciesreplayPersistenceService;
+    private final ReplayVerificationService replayVerificationService;
 
     // Helper classes
-    private final EciesFactory eciesFactory = new EciesFactory();
+    private final EncryptorFactory encryptorFactory = new EncryptorFactory();
     private final KeyConvertor keyConvertor = new KeyConvertor();
     private final PowerAuthServerKeyFactory powerAuthServerKeyFactory = new PowerAuthServerKeyFactory();
     private final ObjectMapper objectMapper;
     private final ActivationHistoryServiceBehavior activationHistoryServiceBehavior;
-    private final KeyGenerator keyGenerator = new KeyGenerator();
 
     // Prepare logger
     private static final Logger logger = LoggerFactory.getLogger(UpgradeServiceBehavior.class);
@@ -93,14 +91,14 @@ public class UpgradeServiceBehavior {
             final RepositoryCatalogue repositoryCatalogue,
             final LocalizationProvider localizationProvider,
             final ServerPrivateKeyConverter serverPrivateKeyConverter,
-            final ReplayVerificationService eciesreplayPersistenceService,
+            final ReplayVerificationService replayVerificationService,
             final ObjectMapper objectMapper,
             final ActivationHistoryServiceBehavior activationHistoryServiceBehavior) {
 
         this.repositoryCatalogue = repositoryCatalogue;
         this.localizationProvider = localizationProvider;
         this.serverPrivateKeyConverter = serverPrivateKeyConverter;
-        this.eciesreplayPersistenceService = eciesreplayPersistenceService;
+        this.replayVerificationService = replayVerificationService;
         this.objectMapper = objectMapper;
         this.activationHistoryServiceBehavior = activationHistoryServiceBehavior;
     }
@@ -112,66 +110,61 @@ public class UpgradeServiceBehavior {
      * @throws GenericServiceException In case upgrade fails.
      */
     public StartUpgradeResponse startUpgrade(StartUpgradeRequest request) throws GenericServiceException{
-        final String activationId = request.getActivationId();
-        final String applicationKey = request.getApplicationKey();
-        final String ephemeralPublicKey = request.getEphemeralPublicKey();
-        final String encryptedData = request.getEncryptedData();
-        final String mac = request.getMac();
-        final String nonce = request.getNonce();
-        // Verify input data
-        if (activationId == null || applicationKey == null || ephemeralPublicKey == null || encryptedData == null || mac == null) {
-            logger.warn("Invalid start upgrade request");
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        }
-
-        final byte[] ephemeralPublicKeyBytes = Base64.getDecoder().decode(ephemeralPublicKey);
-        final byte[] encryptedDataBytes = Base64.getDecoder().decode(encryptedData);
-        final byte[] macBytes = Base64.getDecoder().decode(mac);
-        final byte[] nonceBytes = nonce != null ? Base64.getDecoder().decode(nonce) : null;
-        final String version = request.getProtocolVersion();
-        final Long timestamp = "3.2".equals(version) ? request.getTimestamp() : null;
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.ACTIVATION_SCOPE, version, applicationKey, activationId);
-        final EciesCryptogram eciesCryptogram = EciesCryptogram.builder().ephemeralPublicKey(ephemeralPublicKeyBytes).mac(macBytes).encryptedData(encryptedDataBytes).build();
-        final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
-        final EciesPayload eciesPayload = new EciesPayload(eciesCryptogram, eciesParameters);
-
-        if (eciesPayload.getParameters().getTimestamp() != null) {
-            // Check ECIES request for replay attacks and persist unique value from request
-            eciesreplayPersistenceService.checkAndPersistUniqueValue(
-                    UniqueValueType.ECIES_ACTIVATION_SCOPE,
-                    new Date(eciesPayload.getParameters().getTimestamp()),
-                    ephemeralPublicKeyBytes,
-                    nonceBytes,
-                    activationId);
-        }
-
-        // Lookup the activation
-        final ActivationRecordEntity activation = repositoryCatalogue.getActivationRepository().findActivationWithLock(activationId);
-        if (activation == null) {
-            logger.info("Activation not found, activation ID: {}", activationId);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
-        }
-
-        // Check if the activation is in correct state and version is 2
-        if (!ActivationStatus.ACTIVE.equals(activation.getActivationStatus()) || activation.getVersion() != 2) {
-            logger.info("Activation state is invalid, activation ID: {}", activationId);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE);
-        }
-
-        // Do not verify ctr_data, upgrade response may not be delivered to client, so the client may retry the upgrade
-
-        // Lookup the application version and check that it is supported
-        final ApplicationVersionEntity applicationVersion = repositoryCatalogue.getApplicationVersionRepository().findByApplicationKey(request.getApplicationKey());
-        if (applicationVersion == null || !applicationVersion.getSupported()) {
-            logger.warn("Application version is incorrect, application key: {}", request.getApplicationKey());
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
-        }
-
         try {
+            final String activationId = request.getActivationId();
+            final String applicationKey = request.getApplicationKey();
+            final String protocolVersion = request.getProtocolVersion();
+
+            // Build and validate encrypted request
+            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+                    request.getEphemeralPublicKey(),
+                    request.getEncryptedData(),
+                    request.getMac(),
+                    request.getNonce(),
+                    request.getTimestamp()
+            );
+            if (activationId == null || applicationKey == null ||
+                    !encryptorFactory.getRequestResponseValidator(protocolVersion).validateEncryptedRequest(encryptedRequest)) {
+                logger.warn("Invalid start upgrade request");
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+            }
+
+            if (encryptedRequest.getTimestamp() != null) {
+                // Check ECIES request for replay attacks and persist unique value from request
+                replayVerificationService.checkAndPersistUniqueValue(
+                        UniqueValueType.ECIES_ACTIVATION_SCOPE,
+                        new Date(encryptedRequest.getTimestamp()),
+                        encryptedRequest.getEphemeralPublicKey(),
+                        encryptedRequest.getNonce(),
+                        activationId);
+            }
+
+            // Lookup the activation
+            final ActivationRecordEntity activation = repositoryCatalogue.getActivationRepository().findActivationWithLock(activationId);
+            if (activation == null) {
+                logger.info("Activation not found, activation ID: {}", activationId);
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+            }
+
+            // Check if the activation is in correct state and version is 2
+            if (!ActivationStatus.ACTIVE.equals(activation.getActivationStatus()) || activation.getVersion() != 2) {
+                logger.info("Activation state is invalid, activation ID: {}", activationId);
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE);
+            }
+
+            // Do not verify ctr_data, upgrade response may not be delivered to client, so the client may retry the upgrade
+
+            // Lookup the application version and check that it is supported
+            final ApplicationVersionEntity applicationVersion = repositoryCatalogue.getApplicationVersionRepository().findByApplicationKey(request.getApplicationKey());
+            if (applicationVersion == null || !applicationVersion.getSupported()) {
+                logger.warn("Application version is incorrect, application key: {}", request.getApplicationKey());
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+            }
+
             // Get the server private key, decrypt it if required
             final String serverPrivateKeyFromEntity = activation.getServerPrivateKeyBase64();
             final EncryptionMode serverPrivateKeyEncryptionMode = activation.getServerPrivateKeyEncryption();
@@ -183,24 +176,20 @@ public class UpgradeServiceBehavior {
             final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
 
             // Get ECIES parameters
-            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
             final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConvertor.convertSharedSecretKeyToBytes(transportKey);
 
-            // Get decryptor for the application
-            final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForActivation(
-                    (ECPrivateKey) serverPrivateKey, applicationSecret, transportKeyBytes, EciesSharedInfo1.UPGRADE,
-                    eciesParameters, ephemeralPublicKeyBytes);
+            // Get server encryptor
+            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+                    EncryptorId.UPGRADE,
+                    new EncryptorParameters(protocolVersion, applicationKey, activationId),
+                    new ServerEncryptorSecrets(serverPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+            );
 
             // Try to decrypt request data, the data must not be empty. Currently only '{}' is sent in request data.
-            final byte[] decryptedData = decryptor.decrypt(eciesPayload);
-            if (decryptedData.length == 0) {
-                logger.warn("Invalid decrypted request data");
-                // Rollback is not required, error occurs before writing to database
-                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
-            }
+            final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
 
             // Request is valid, generate hash based counter if it does not exist yet
             final String ctrDataBase64;
@@ -226,18 +215,13 @@ public class UpgradeServiceBehavior {
             // Encrypt response payload and return it
             final byte[] payloadBytes = objectMapper.writeValueAsBytes(payload);
 
-            final byte[] nonceBytesResponse = "3.2".equals(version) ? keyGenerator.generateRandomBytes(16) : nonceBytes;
-            final Long timestampResponse = "3.2".equals(version) ? new Date().getTime() : null;
-            final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
-            final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.ACTIVATION_SCOPE,
-                    decryptor.getEnvelopeKey(), applicationSecret, transportKeyBytes, parametersResponse);
+            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(payloadBytes);
 
-            final EciesPayload payloadResponse = encryptorResponse.encrypt(payloadBytes, parametersResponse);
             final StartUpgradeResponse response = new StartUpgradeResponse();
-            response.setEncryptedData(Base64.getEncoder().encodeToString(payloadResponse.getCryptogram().getEncryptedData()));
-            response.setMac(Base64.getEncoder().encodeToString(payloadResponse.getCryptogram().getMac()));
-            response.setNonce("3.2".equals(version) && nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
-            response.setTimestamp(timestampResponse);
+            response.setEncryptedData(encryptedResponse.getEncryptedData());
+            response.setMac(encryptedResponse.getMac());
+            response.setNonce(encryptedResponse.getNonce());
+            response.setTimestamp(encryptedResponse.getTimestamp());
 
             // Save activation as last step to avoid rollbacks
             if (activationShouldBeSaved) {
@@ -249,7 +233,7 @@ public class UpgradeServiceBehavior {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, cryptography errors can only occur before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
-        } catch (EciesException ex) {
+        } catch (EncryptorException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, cryptography errors can only occur before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -39,11 +39,14 @@ import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvide
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.request.VaultUnlockRequestPayload;
 import io.getlime.security.powerauth.app.server.service.model.response.VaultUnlockResponsePayload;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesDecryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.*;
+import io.getlime.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -57,11 +60,9 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.*;
 
@@ -83,10 +84,10 @@ public class VaultUnlockServiceBehavior {
     private final LocalizationProvider localizationProvider;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
     private final ServiceBehaviorCatalogue behavior;
-    private final ReplayVerificationService eciesreplayPersistenceService;
+    private final ReplayVerificationService replayVerificationService;
 
     // Helper classes
-    private final EciesFactory eciesFactory = new EciesFactory();
+    private final EncryptorFactory encryptorFactory = new EncryptorFactory();
     private final KeyGenerator keyGenerator = new KeyGenerator();
     private final PowerAuthServerVault powerAuthServerVault = new PowerAuthServerVault();
     private final ObjectMapper objectMapper;
@@ -96,12 +97,12 @@ public class VaultUnlockServiceBehavior {
     private static final Logger logger = LoggerFactory.getLogger(VaultUnlockServiceBehavior.class);
 
     @Autowired
-    public VaultUnlockServiceBehavior(RepositoryCatalogue repositoryCatalogue, LocalizationProvider localizationProvider, ServerPrivateKeyConverter serverPrivateKeyConverter, ServiceBehaviorCatalogue behavior, ReplayVerificationService eciesreplayPersistenceService, ObjectMapper objectMapper) {
+    public VaultUnlockServiceBehavior(RepositoryCatalogue repositoryCatalogue, LocalizationProvider localizationProvider, ServerPrivateKeyConverter serverPrivateKeyConverter, ServiceBehaviorCatalogue behavior, ReplayVerificationService replayVerificationService, ObjectMapper objectMapper) {
         this.repositoryCatalogue = repositoryCatalogue;
         this.localizationProvider = localizationProvider;
         this.serverPrivateKeyConverter = serverPrivateKeyConverter;
         this.behavior = behavior;
-        this.eciesreplayPersistenceService = eciesreplayPersistenceService;
+        this.replayVerificationService = replayVerificationService;
         this.objectMapper = objectMapper;
     }
 
@@ -116,15 +117,20 @@ public class VaultUnlockServiceBehavior {
      * @param signature              PowerAuth signature.
      * @param signatureType          PowerAuth signature type.
      * @param signatureVersion       PowerAuth signature version.
-     * @param eciesPayload           ECIES payload.
+     * @param encryptedRequest       Encrypted request data.
      * @param keyConversion          Key conversion utilities.
      * @return Vault unlock response with a properly encrypted vault unlock key.
      * @throws GenericServiceException In case server private key decryption fails.
      */
     public VaultUnlockResponse unlockVault(String activationId, String applicationKey, String signature, SignatureType signatureType, String signatureVersion,
-                                           String signedData, EciesPayload eciesPayload, KeyConvertor keyConversion)
+                                           String signedData, EncryptedRequest encryptedRequest, KeyConvertor keyConversion)
             throws GenericServiceException {
         try {
+            if (!encryptorFactory.getRequestResponseValidator(signatureVersion).validateEncryptedRequest(encryptedRequest)) {
+                logger.warn("Invalid encrypted request parameters in method vaultUnlock");
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+            }
             // Lookup the activation
             final ActivationRecordEntity activation = repositoryCatalogue.getActivationRepository().findActivationWithoutLock(activationId);
 
@@ -155,30 +161,30 @@ public class VaultUnlockServiceBehavior {
                 return response;
             }
 
-            if (eciesPayload.getParameters().getTimestamp() != null) {
+            if (encryptedRequest.getTimestamp() != null) {
                 // Check ECIES request for replay attacks and persist unique value from request
-                eciesreplayPersistenceService.checkAndPersistUniqueValue(
+                replayVerificationService.checkAndPersistUniqueValue(
                         UniqueValueType.ECIES_ACTIVATION_SCOPE,
-                        new Date(eciesPayload.getParameters().getTimestamp()),
-                        eciesPayload.getCryptogram().getEphemeralPublicKey(),
-                        eciesPayload.getParameters().getNonce(),
+                        new Date(encryptedRequest.getTimestamp()),
+                        encryptedRequest.getEphemeralPublicKey(),
+                        encryptedRequest.getNonce(),
                         activationId);
             }
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
-            final byte[] applicationSecret = applicationVersion.getApplicationSecret().getBytes(StandardCharsets.UTF_8);
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
             final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConversion.convertSharedSecretKeyToBytes(transportKey);
 
-            // Get decryptor for the activation
-            final EciesDecryptor decryptor = eciesFactory.getEciesDecryptorForActivation((ECPrivateKey) serverPrivateKey,
-                    applicationSecret, transportKeyBytes, EciesSharedInfo1.VAULT_UNLOCK, eciesPayload.getParameters(),
-                    eciesPayload.getCryptogram().getEphemeralPublicKey());
-
+            // Get server encryptor
+            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+                    EncryptorId.VAULT_UNLOCK,
+                    new EncryptorParameters(signatureVersion, applicationKey, activationId),
+                    new ServerEncryptorSecrets(serverPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+            );
             // Decrypt request to obtain vault unlock reason
-            final byte[] decryptedData = decryptor.decrypt(eciesPayload);
+            final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
 
             // Convert JSON data to vault unlock request object
             VaultUnlockRequestPayload request;
@@ -225,22 +231,14 @@ public class VaultUnlockServiceBehavior {
             final byte[] reponsePayloadBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response payload
-            final byte[] nonceBytesResponse = "3.2".equals(signatureVersion) ? keyGenerator.generateRandomBytes(16) : eciesPayload.getParameters().getNonce();
-            final Long timestampResponse = "3.2".equals(signatureVersion) ? new Date().getTime() : null;
-            final EciesParameters parametersResponse = EciesParameters.builder().nonce(nonceBytesResponse).associatedData(eciesPayload.getParameters().getAssociatedData()).timestamp(timestampResponse).build();
-            final EciesEncryptor encryptorResponse = eciesFactory.getEciesEncryptor(EciesScope.ACTIVATION_SCOPE,
-                    decryptor.getEnvelopeKey(), applicationSecret, transportKeyBytes, parametersResponse);
-
-            final EciesPayload responseEciesPayload = encryptorResponse.encrypt(reponsePayloadBytes, parametersResponse);
-            final String dataResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getEncryptedData());
-            final String macResponse = Base64.getEncoder().encodeToString(responseEciesPayload.getCryptogram().getMac());
+            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(reponsePayloadBytes);
 
             // Return vault unlock response, set signature validity
             final VaultUnlockResponse response = new VaultUnlockResponse();
-            response.setEncryptedData(dataResponse);
-            response.setMac(macResponse);
-            response.setNonce("3.2".equals(signatureVersion) && nonceBytesResponse != null ? Base64.getEncoder().encodeToString(nonceBytesResponse) : null);
-            response.setTimestamp(timestampResponse);
+            response.setEncryptedData(encryptedResponse.getEncryptedData());
+            response.setMac(encryptedResponse.getMac());
+            response.setNonce(encryptedResponse.getNonce());
+            response.setTimestamp(encryptedResponse.getTimestamp());
             response.setSignatureValid(signatureResponse.isSignatureValid());
             return response;
         } catch (InvalidKeyException | InvalidKeySpecException ex) {
@@ -249,7 +247,7 @@ public class VaultUnlockServiceBehavior {
             // The only possible error could occur while generating ECIES response after signature validation,
             // however this logic is well tested and should not fail.
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
-        } catch (EciesException ex) {
+        } catch (EncryptorException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, cryptography errors can only occur before writing to database.
             // The only possible error could occur while generating ECIES response after signature validation,

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/replay/ReplayVerificationService.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/replay/ReplayVerificationService.java
@@ -106,8 +106,8 @@ public class ReplayVerificationService {
         }
         if (!replayPersistenceService.persistUniqueValue(type, uniqueValue)) {
             logger.warn("Unique value could not be persisted");
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+            // The whole transaction is rolled back in case of this unexpected state
+            throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
         }
     }
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/replay/ReplayVerificationService.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/replay/ReplayVerificationService.java
@@ -65,45 +65,39 @@ public class ReplayVerificationService {
      * Check whether unique value exists for MAC Token request.
      * @param type Unique value type.
      * @param requestTimestamp Request timestamp.
-     * @param nonceBytes Nonce bytes.
+     * @param nonce Nonce bytes encoded in Base64.
      * @param identifier Identifier for the record.
      * @throws GenericServiceException Thrown in case unique value exists.
      */
-    public void checkAndPersistUniqueValue(UniqueValueType type, Date requestTimestamp, byte[] nonceBytes, String identifier) throws GenericServiceException {
-        checkAndPersistUniqueValue(type, requestTimestamp, new byte[0], nonceBytes, identifier);
+    public void checkAndPersistUniqueValue(UniqueValueType type, Date requestTimestamp, String nonce, String identifier) throws GenericServiceException {
+        checkAndPersistUniqueValue(type, requestTimestamp, null, nonce, identifier);
     }
 
     /**
      * Check whether unique value exists for ECIES request.
      * @param type Unique value type.
      * @param requestTimestamp Request timestamp.
-     * @param ephemeralPublicKeyBytes Ephemeral public key bytes.
-     * @param nonceBytes Nonce bytes.
+     * @param ephemeralPublicKey Ephemeral public key bytes encoded in Base64.
+     * @param nonce Nonce bytes encoded in Base64.
      * @param identifier Identifier for the record.
      * @throws GenericServiceException Thrown in case unique value exists.
      */
-    public void checkAndPersistUniqueValue(UniqueValueType type, Date requestTimestamp, byte[] ephemeralPublicKeyBytes, byte[] nonceBytes, String identifier) throws GenericServiceException {
+    public void checkAndPersistUniqueValue(UniqueValueType type, Date requestTimestamp, String ephemeralPublicKey, String nonce, String identifier) throws GenericServiceException {
         final Date expiration = Date.from(Instant.now().plus(config.getRequestExpirationInMilliseconds(), ChronoUnit.MILLIS));
         if (requestTimestamp.after(expiration)) {
             // Rollback is not required, error occurs before writing to database
             logger.warn("Expired ECIES request received, timestamp: {}", requestTimestamp);
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
         }
-
+        final byte[] ephemeralPublicKeyBytes = ephemeralPublicKey != null ? Base64.getDecoder().decode(ephemeralPublicKey) : new byte[0];
+        final byte[] nonceBytes = nonce != null ? Base64.getDecoder().decode(nonce) : new byte[0];
         final byte[] identifierBytes = identifier != null ? identifier.getBytes(StandardCharsets.UTF_8) : new byte[0];
-        final ByteBuffer uniqueValBuffer = ByteBuffer.allocate(
-                (ephemeralPublicKeyBytes != null ? ephemeralPublicKeyBytes.length : 0)
-                        + (nonceBytes != null ? nonceBytes.length : 0)
-                        + identifierBytes.length);
-        if (ephemeralPublicKeyBytes != null) {
-            uniqueValBuffer.put(ephemeralPublicKeyBytes);
-        }
-        if (nonceBytes != null) {
-            uniqueValBuffer.put(nonceBytes);
-        }
-        if (identifier != null) {
-            uniqueValBuffer.put(identifierBytes);
-        }
+
+        final ByteBuffer uniqueValBuffer = ByteBuffer.allocate(ephemeralPublicKeyBytes.length + nonceBytes.length + identifierBytes.length);
+        uniqueValBuffer.put(ephemeralPublicKeyBytes);
+        uniqueValBuffer.put(nonceBytes);
+        uniqueValBuffer.put(identifierBytes);
+
         final String uniqueValue = Base64.getEncoder().encodeToString(uniqueValBuffer.array());
         if (replayPersistenceService.uniqueValueExists(uniqueValue)) {
             logger.warn("Duplicate request not allowed to prevent replay attacks");

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -3,14 +3,19 @@ package io.getlime.security.powerauth.app.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
 import com.wultra.security.powerauth.client.model.request.*;
-import com.wultra.security.powerauth.client.model.response.*;
-import io.getlime.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
+import com.wultra.security.powerauth.client.model.response.CreateActivationResponse;
+import com.wultra.security.powerauth.client.model.response.CreateApplicationResponse;
+import com.wultra.security.powerauth.client.model.response.CreateApplicationVersionResponse;
+import com.wultra.security.powerauth.client.model.response.GetApplicationDetailResponse;
 import io.getlime.security.powerauth.app.server.service.PowerAuthService;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
-import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.*;
+import io.getlime.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
-import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -20,10 +25,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PublicKey;
-import java.security.interfaces.ECPublicKey;
 import java.util.*;
 
 @SpringBootTest
@@ -34,6 +37,7 @@ public class VerifySignatureConcurrencyTest {
     private PowerAuthService powerAuthService;
 
     private final KeyConvertor keyConvertor = new KeyConvertor();
+    private final EncryptorFactory encryptorFactory = new EncryptorFactory();
 
     @Autowired
     public void setPowerAuthService(PowerAuthService powerAuthService) {
@@ -73,21 +77,19 @@ public class VerifySignatureConcurrencyTest {
         detailRequest.setApplicationId(createApplicationResponse.getApplicationId());
         GetApplicationDetailResponse detailResponse = powerAuthService.getApplicationDetail(detailRequest);
 
-        ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
+        PublicKey masterPublicKey = keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
 
         final String version = "3.2";
         final String applicationKey = createApplicationVersionResponse.getApplicationKey();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, version, applicationKey, null);
-        final Long timestamp = new Date().getTime();
-        final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
-        final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
+        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+                EncryptorId.ACTIVATION_LAYER_2,
+                new EncryptorParameters(version, applicationKey, null),
+                new ClientEncryptorSecrets(masterPublicKey, createApplicationVersionResponse.getApplicationSecret())
+        );
 
-        EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey,
-                createApplicationVersionResponse.getApplicationSecret().getBytes(StandardCharsets.UTF_8),
-                EciesSharedInfo1.ACTIVATION_LAYER_2, eciesParameters);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new ObjectMapper().writeValue(baos, requestL2);
-        EciesPayload eciesPayload = eciesEncryptor.encrypt(baos.toByteArray(), eciesParameters);
+        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(baos.toByteArray());
 
         // Create activation
         CreateActivationRequest createActivationRequest = new CreateActivationRequest();
@@ -95,12 +97,12 @@ public class VerifySignatureConcurrencyTest {
         createActivationRequest.setTimestampActivationExpire(expiration.getTime());
         createActivationRequest.setMaxFailureCount(5L);
         createActivationRequest.setApplicationKey(createApplicationVersionResponse.getApplicationKey());
-        createActivationRequest.setEncryptedData(Base64.getEncoder().encodeToString(eciesPayload.getCryptogram().getEncryptedData()));
-        createActivationRequest.setMac(Base64.getEncoder().encodeToString(eciesPayload.getCryptogram().getMac()));
-        createActivationRequest.setEphemeralPublicKey(Base64.getEncoder().encodeToString(eciesPayload.getCryptogram().getEphemeralPublicKey()));
-        createActivationRequest.setNonce(Base64.getEncoder().encodeToString(eciesPayload.getParameters().getNonce()));
-        createActivationRequest.setTimestamp(timestamp);
-        createActivationRequest.setProtocolVersion("3.2");
+        createActivationRequest.setEphemeralPublicKey(encryptedRequest.getEphemeralPublicKey());
+        createActivationRequest.setEncryptedData(encryptedRequest.getEncryptedData());
+        createActivationRequest.setMac(encryptedRequest.getMac());
+        createActivationRequest.setNonce(encryptedRequest.getNonce());
+        createActivationRequest.setTimestamp(encryptedRequest.getTimestamp());
+        createActivationRequest.setProtocolVersion(version);
         CreateActivationResponse createActivationResponse = powerAuthService.createActivation(createActivationRequest);
 
         // Commit activation


### PR DESCRIPTION
This PR replaces usage of low level ECIES with a new general encryptor facility introduced in wultra/powerauth-crypto#493 

This PR will fix:
- #957
- #956

TODO:
- We have to properly check usage of replay verification service. It's clear that such service store data to database in case that entry is new (e.g. there's no replay attack), so all our comments about transaction rollback in exceptions appears to be inaccurate.
- Documentation