### PR TITLE
Fix #762: Insufficient input validation in activation prepare endpoint

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/entity/RecoveryCodeEntity.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/entity/RecoveryCodeEntity.java
@@ -72,7 +72,7 @@ public class RecoveryCodeEntity implements Serializable {
     @Column(name = "timestamp_created", nullable = false)
     private Date timestampCreated;
 
-    @Column(name = "timestamp_last_used", nullable = false)
+    @Column(name = "timestamp_last_used")
     private Date timestampLastUsed;
 
     @Column(name = "timestamp_last_change")

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.audit.base.util.StringUtil;
 import com.wultra.security.powerauth.client.model.entity.Activation;
 import com.wultra.security.powerauth.client.model.request.RecoveryCodeActivationRequest;
 import com.wultra.security.powerauth.client.model.response.*;
@@ -68,6 +69,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;
@@ -908,7 +910,7 @@ public class ActivationServiceBehavior {
 
             // Ensure presence of the devicePublicKey
             final String retrievedDevicePublicKey = request.getDevicePublicKey();
-            if (retrievedDevicePublicKey == null || retrievedDevicePublicKey.isEmpty()) {
+            if (!StringUtils.hasText(retrievedDevicePublicKey)) {
                 logger.warn("Invalid activation request, activation code: {}", activationCode);
                 // Rollback is not required, error occurs before writing to database
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
@@ -1156,7 +1158,7 @@ public class ActivationServiceBehavior {
 
             // Ensure presence of the devicePublicKey
             final String retrievedDevicePublicKey = request.getDevicePublicKey();
-            if (retrievedDevicePublicKey == null || retrievedDevicePublicKey.isEmpty()) {
+            if (!StringUtils.hasText(retrievedDevicePublicKey)) {
                 logger.warn("Invalid activation request, activation ID: {}", activationId);
                 // Activation failed due to invalid ECIES request, rollback transaction
                 throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
@@ -1713,7 +1715,7 @@ public class ActivationServiceBehavior {
 
             // Ensure presence of the devicePublicKey
             final String retrievedDevicePublicKey = layer2Request.getDevicePublicKey();
-            if (retrievedDevicePublicKey == null || retrievedDevicePublicKey.isEmpty()) {
+            if (!StringUtils.hasText(retrievedDevicePublicKey)) {
                 logger.warn("Invalid activation request, recovery code: {}", recoveryCode);
                 // Rollback is not required, error occurs before writing to database
                 throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -1161,7 +1161,7 @@ public class ActivationServiceBehavior {
             if (!StringUtils.hasText(retrievedDevicePublicKey)) {
                 logger.warn("Invalid activation request, activation ID: {}", activationId);
                 // Activation failed due to invalid ECIES request, rollback transaction
-                throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+                throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.INVALID_REQUEST);
             }
 
             // Extract the device public key from request
@@ -1718,7 +1718,7 @@ public class ActivationServiceBehavior {
             if (!StringUtils.hasText(retrievedDevicePublicKey)) {
                 logger.warn("Invalid activation request, recovery code: {}", recoveryCode);
                 // Rollback is not required, error occurs before writing to database
-                throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
+                throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.INVALID_REQUEST);
             }
 
             // Get recovery code entity

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -19,7 +19,6 @@ package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wultra.core.audit.base.util.StringUtil;
 import com.wultra.security.powerauth.client.model.entity.Activation;
 import com.wultra.security.powerauth.client.model.request.RecoveryCodeActivationRequest;
 import com.wultra.security.powerauth.client.model.response.*;

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -73,13 +73,13 @@ public class ActivationServiceBehaviorTest {
     void testPrepareActivationWithValidPayload() throws Exception {
 
         // Create application
-        final GetApplicationDetailResponse detailResponse = this.createApplication();
+        final GetApplicationDetailResponse detailResponse = createApplication();
 
         // Initiate activation of a user
-        final InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
+        final InitActivationResponse initActivationResponse = initActivation(detailResponse.getApplicationId());
         final String activationId = initActivationResponse.getActivationId();
 
-        assertEquals(ActivationStatus.CREATED, this.getActivationStatus(activationId));
+        assertEquals(ActivationStatus.CREATED, getActivationStatus(activationId));
 
         // Generate public key for a client device
         final KeyGenerator keyGenerator = new KeyGenerator();
@@ -89,41 +89,41 @@ public class ActivationServiceBehaviorTest {
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
-        final EciesPayload correctEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesPayload correctEciesPayload = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation
         assertDoesNotThrow(() -> tested.prepareActivation(
                 initActivationResponse.getActivationCode(), detailResponse.getVersions().get(0).getApplicationKey(),
-                false, correctEciesPayload, this.version, this.keyConvertor));
+                false, correctEciesPayload, version, keyConvertor));
 
-        assertEquals(ActivationStatus.PENDING_COMMIT, this.getActivationStatus(activationId));
+        assertEquals(ActivationStatus.PENDING_COMMIT, getActivationStatus(activationId));
     }
 
     @Test
     void testPrepareActivationWithInvalidPayload() throws Exception {
 
         // Create application
-        final GetApplicationDetailResponse detailResponse = this.createApplication();
+        final GetApplicationDetailResponse detailResponse = createApplication();
 
         // Initiate activation of a user
-        final InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
+        final InitActivationResponse initActivationResponse = initActivation(detailResponse.getApplicationId());
         final String activationId = initActivationResponse.getActivationId();
 
-        assertEquals(ActivationStatus.CREATED, this.getActivationStatus(activationId));
+        assertEquals(ActivationStatus.CREATED, getActivationStatus(activationId));
 
         // Create request payload, omit device public key
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        final EciesPayload invalidEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesPayload invalidEciesPayload = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation with missing devicePublicKey
         GenericServiceException exception = assertThrows(
                 GenericServiceException.class,
                 () -> tested.prepareActivation(initActivationResponse.getActivationCode(),
                         detailResponse.getVersions().get(0).getApplicationKey(),
-                        false, invalidEciesPayload, this.version, this.keyConvertor));
+                        false, invalidEciesPayload, version, keyConvertor));
         assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
 
-        assertEquals(ActivationStatus.CREATED, this.getActivationStatus(activationId));
+        assertEquals(ActivationStatus.CREATED, getActivationStatus(activationId));
     }
 
     private EciesPayload buildPrepareActivationPayload(ActivationLayer2Request requestL2,
@@ -131,7 +131,7 @@ public class ActivationServiceBehaviorTest {
 
         // Set parameters
         final String applicationKey = applicationDetail.getVersions().get(0).getApplicationKey();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, this.version, applicationKey, null);
+        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, version, applicationKey, null);
         final Long timestamp = new Date().getTime();
         final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
         final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
@@ -153,7 +153,7 @@ public class ActivationServiceBehaviorTest {
         return tested.initActivation(
                 applicationId, userId,
                 null, null, null,null,null,
-                this.keyConvertor);
+                keyConvertor);
     }
 
     private GetApplicationDetailResponse createApplication() throws Exception {

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @SpringBootTest
 @Transactional
-public class ActivationServiceBehaviorTest {
+class ActivationServiceBehaviorTest {
 
     @Autowired
     private ActivationServiceBehavior tested;

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -114,7 +114,7 @@ class ActivationServiceBehaviorTest {
         final EciesPayload invalidEciesPayload = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation with missing devicePublicKey
-        GenericServiceException exception = assertThrows(
+        final GenericServiceException exception = assertThrows(
                 GenericServiceException.class,
                 () -> tested.prepareActivation(initActivationResponse.getActivationCode(),
                         detailResponse.getVersions().get(0).getApplicationKey(),

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -82,13 +82,11 @@ public class ActivationServiceBehaviorTest {
         assertEquals(ActivationStatus.CREATED, getActivationStatus(activationId));
 
         // Generate public key for a client device
-        final KeyGenerator keyGenerator = new KeyGenerator();
-        final KeyPair keyPair = keyGenerator.generateKeyPair();
-        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(keyPair.getPublic());
+        final String publicKey = generatePublicKey();
 
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
+        requestL2.setDevicePublicKey(publicKey);
         final EciesPayload correctEciesPayload = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation
@@ -133,13 +131,11 @@ public class ActivationServiceBehaviorTest {
         final GetApplicationDetailResponse detailResponse = createApplication();
 
         // Generate public key for a client device
-        final KeyGenerator keyGenerator = new KeyGenerator();
-        final KeyPair keyPair = keyGenerator.generateKeyPair();
-        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(keyPair.getPublic());
+        final String publicKey = generatePublicKey();
 
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
+        requestL2.setDevicePublicKey(publicKey);
         final EciesPayload correctEciesPayload = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Create activation
@@ -371,7 +367,6 @@ public class ActivationServiceBehaviorTest {
     }
 
     private InitActivationResponse initActivation(String applicationId) throws Exception {
-        final String userId = UUID.randomUUID().toString();
         return tested.initActivation(
                 applicationId, userId,
                 null, null, null,null,null,

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -168,7 +168,6 @@ public class ActivationServiceBehaviorTest {
     }
 
     private ActivationStatus getActivationStatus(String activationId) throws Exception {
-        // Check status prepared
         final GetActivationStatusRequest statusRequest = new GetActivationStatusRequest();
         statusRequest.setActivationId(activationId);
         GetActivationStatusResponse statusResponse = powerAuthService.getActivationStatus(statusRequest);

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -1,0 +1,98 @@
+package io.getlime.security.powerauth.app.server.service.behavior.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.security.powerauth.client.model.request.CreateApplicationRequest;
+import com.wultra.security.powerauth.client.model.request.CreateApplicationVersionRequest;
+import com.wultra.security.powerauth.client.model.request.GetApplicationDetailRequest;
+import com.wultra.security.powerauth.client.model.response.CreateApplicationResponse;
+import com.wultra.security.powerauth.client.model.response.CreateApplicationVersionResponse;
+import com.wultra.security.powerauth.client.model.response.GetApplicationDetailResponse;
+import io.getlime.security.powerauth.app.server.service.PowerAuthService;
+import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import io.getlime.security.powerauth.app.server.service.model.ServiceError;
+import io.getlime.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesFactory;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesParameters;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesPayload;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
+import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
+import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class ActivationServiceBehaviorTest {
+
+    @Autowired
+    private ActivationServiceBehavior tested;
+
+    @Autowired
+    private PowerAuthService powerAuthService;
+
+    private final KeyConvertor keyConvertor = new KeyConvertor();
+
+    @Test
+    void testPrepareActivation() throws Exception {
+        // Testing validation of encrypted data, sent in activation prepare endpoint.
+
+        String testId = UUID.randomUUID().toString();
+        CreateApplicationRequest createApplicationRequest = new CreateApplicationRequest();
+        createApplicationRequest.setApplicationId(testId);
+        CreateApplicationResponse createApplicationResponse = powerAuthService.createApplication(createApplicationRequest);
+
+        CreateApplicationVersionRequest createApplicationVersionRequest = new CreateApplicationVersionRequest();
+        createApplicationVersionRequest.setApplicationId(createApplicationResponse.getApplicationId());
+        createApplicationVersionRequest.setApplicationVersionId("test");
+        CreateApplicationVersionResponse createApplicationVersionResponse = powerAuthService.createApplicationVersion(createApplicationVersionRequest);
+
+        GetApplicationDetailRequest detailRequest = new GetApplicationDetailRequest();
+        detailRequest.setApplicationId(createApplicationResponse.getApplicationId());
+        GetApplicationDetailResponse detailResponse = powerAuthService.getApplicationDetail(detailRequest);
+
+        ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
+
+        // Build Request; omit devicePublicKey for this test
+        // other attributes have logic based on null value or are optional
+        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
+
+        final String version = "3.2";
+        String activationCode = "AAAAA-BBBBB-CCCCC-DDDDD";
+        boolean shouldGenerateRecoveryCodes = false;
+        final String applicationKey = createApplicationVersionResponse.getApplicationKey();
+        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, version, applicationKey, null);
+        final Long timestamp = new Date().getTime();
+        final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
+        final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
+
+        EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey,
+                createApplicationVersionResponse.getApplicationSecret().getBytes(StandardCharsets.UTF_8),
+                EciesSharedInfo1.ACTIVATION_LAYER_2, eciesParameters);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new ObjectMapper().writeValue(baos, requestL2);
+        EciesPayload eciesPayload = eciesEncryptor.encrypt(baos.toByteArray(), eciesParameters);
+
+
+        Executable executable = () -> tested.prepareActivation(activationCode, applicationKey,
+                shouldGenerateRecoveryCodes, eciesPayload, version, this.keyConvertor);
+        GenericServiceException exception = assertThrows(GenericServiceException.class, executable);
+        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
+    }
+
+}

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -1,3 +1,20 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -50,7 +50,13 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test for {@link ActivationServiceBehavior}.
+ *
+ * @author Jan Pesek, janpesek@outlook.com
+ */
 @SpringBootTest
+@Transactional
 public class ActivationServiceBehaviorTest {
 
     @Autowired
@@ -63,8 +69,7 @@ public class ActivationServiceBehaviorTest {
     private final String version = "3.2";
 
     @Test
-    @Transactional
-    void testPrepareActivationWithValidPayload() throws Exception {
+    public void testPrepareActivationWithValidPayload() throws Exception {
 
         // Create application
         GetApplicationDetailResponse detailResponse = this.createApplication();
@@ -90,8 +95,7 @@ public class ActivationServiceBehaviorTest {
     }
 
     @Test
-    @Transactional
-    void testPrepareActivationWithInvalidPayload() throws Exception {
+    public void testPrepareActivationWithInvalidPayload() throws Exception {
 
         // Create application
         GetApplicationDetailResponse detailResponse = this.createApplication();

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -72,21 +72,20 @@ public class ActivationServiceBehaviorTest {
     public void testPrepareActivationWithValidPayload() throws Exception {
 
         // Create application
-        GetApplicationDetailResponse detailResponse = this.createApplication();
+        final GetApplicationDetailResponse detailResponse = this.createApplication();
 
         // Initiate activation of a user
-        InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
+        final InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
 
         // Generate public key for a client device
-        KeyGenerator keyGenerator = new KeyGenerator();
-        KeyPair keyPair = keyGenerator.generateKeyPair();
-        PublicKey publicKey = keyPair.getPublic();
-        byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
+        final KeyGenerator keyGenerator = new KeyGenerator();
+        final KeyPair keyPair = keyGenerator.generateKeyPair();
+        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(keyPair.getPublic());
 
         // Create request payload
-        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
+        final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
-        EciesPayload correctEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesPayload correctEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation
         assertDoesNotThrow(() -> tested.prepareActivation(
@@ -98,14 +97,14 @@ public class ActivationServiceBehaviorTest {
     public void testPrepareActivationWithInvalidPayload() throws Exception {
 
         // Create application
-        GetApplicationDetailResponse detailResponse = this.createApplication();
+        final GetApplicationDetailResponse detailResponse = this.createApplication();
 
         // Initiate activation of a user
-        InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
+        final InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
 
         // Create request payload, omit device public key
-        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        EciesPayload invalidEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
+        final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
+        final EciesPayload invalidEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation with missing devicePublicKey
         GenericServiceException exception = assertThrows(
@@ -130,16 +129,16 @@ public class ActivationServiceBehaviorTest {
                 Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
 
         // Encrypt payload
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new ObjectMapper().writeValue(baos, requestL2);
-        EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey,
+        final EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey,
                 applicationDetail.getVersions().get(0).getApplicationSecret().getBytes(StandardCharsets.UTF_8),
                 EciesSharedInfo1.ACTIVATION_LAYER_2, eciesParameters);
         return eciesEncryptor.encrypt(baos.toByteArray(), eciesParameters);
     }
 
     private InitActivationResponse initActivation(String applicationId) throws Exception {
-        String userId = UUID.randomUUID().toString();
+        final String userId = UUID.randomUUID().toString();
         return tested.initActivation(
                 applicationId, userId,
                 null, null, null,null,null,
@@ -147,12 +146,12 @@ public class ActivationServiceBehaviorTest {
     }
 
     private GetApplicationDetailResponse createApplication() throws Exception {
-        String testId = UUID.randomUUID().toString();
-        CreateApplicationRequest createApplicationRequest = new CreateApplicationRequest();
+        final String testId = UUID.randomUUID().toString();
+        final CreateApplicationRequest createApplicationRequest = new CreateApplicationRequest();
         createApplicationRequest.setApplicationId(testId);
-        CreateApplicationResponse createApplicationResponse = powerAuthService.createApplication(createApplicationRequest);
+        final CreateApplicationResponse createApplicationResponse = powerAuthService.createApplication(createApplicationRequest);
 
-        GetApplicationDetailRequest detailRequest = new GetApplicationDetailRequest();
+        final GetApplicationDetailRequest detailRequest = new GetApplicationDetailRequest();
         detailRequest.setApplicationId(createApplicationResponse.getApplicationId());
         return powerAuthService.getApplicationDetail(detailRequest);
     }

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -17,6 +17,8 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 
+// TODO Lubos resolve conflicts and rewrite to EncryptorFactory
+/*
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.enumeration.RecoveryCodeStatus;
@@ -48,6 +50,7 @@ import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+*/
 
 /**
  * Test for {@link ActivationServiceBehavior}.
@@ -57,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @Transactional
 class ActivationServiceBehaviorTest {
-
+/*
     @Autowired
     private ActivationServiceBehavior tested;
 
@@ -391,5 +394,5 @@ class ActivationServiceBehaviorTest {
 
         return statusResponse.getActivationStatus();
     }
-
+*/
 }

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -2,14 +2,10 @@ package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.model.request.CreateApplicationRequest;
-import com.wultra.security.powerauth.client.model.request.CreateApplicationVersionRequest;
 import com.wultra.security.powerauth.client.model.request.GetApplicationDetailRequest;
-import com.wultra.security.powerauth.client.model.response.CreateApplicationResponse;
-import com.wultra.security.powerauth.client.model.response.CreateApplicationVersionResponse;
-import com.wultra.security.powerauth.client.model.response.GetApplicationDetailResponse;
+import com.wultra.security.powerauth.client.model.response.*;
 import io.getlime.security.powerauth.app.server.service.PowerAuthService;
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
-import io.getlime.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.EciesEncryptor;
@@ -22,9 +18,9 @@ import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.util.EciesUtils;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -47,52 +43,97 @@ public class ActivationServiceBehaviorTest {
     private PowerAuthService powerAuthService;
 
     private final KeyConvertor keyConvertor = new KeyConvertor();
+    private final String version = "3.2";
 
     @Test
-    void testPrepareActivation() throws Exception {
-        // Testing validation of encrypted data, sent in activation prepare endpoint.
+    @Transactional
+    void testPrepareActivationWithValidPayload() throws Exception {
 
+        // Create application
+        GetApplicationDetailResponse detailResponse = this.createApplication();
+
+        // Initiate activation of a user
+        InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
+
+        // Generate public key for a client device
+        KeyGenerator keyGenerator = new KeyGenerator();
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
+
+        // Create request payload
+        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
+        requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
+        EciesPayload correctEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
+
+        // Prepare activation
+        assertDoesNotThrow(() -> tested.prepareActivation(
+                initActivationResponse.getActivationCode(), detailResponse.getVersions().get(0).getApplicationKey(),
+                false, correctEciesPayload, this.version, this.keyConvertor));
+    }
+
+    @Test
+    @Transactional
+    void testPrepareActivationWithInvalidPayload() throws Exception {
+
+        // Create application
+        GetApplicationDetailResponse detailResponse = this.createApplication();
+
+        // Initiate activation of a user
+        InitActivationResponse initActivationResponse = this.initActivation(detailResponse.getApplicationId());
+
+        // Create request payload, omit device public key
+        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
+        EciesPayload invalidEciesPayload = this.buildPrepareActivationPayload(requestL2, detailResponse);
+
+        // Prepare activation with missing devicePublicKey
+        GenericServiceException exception = assertThrows(
+                GenericServiceException.class,
+                () -> tested.prepareActivation(initActivationResponse.getActivationCode(),
+                        detailResponse.getVersions().get(0).getApplicationKey(),
+                        false, invalidEciesPayload, this.version, this.keyConvertor));
+        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
+    }
+
+    private EciesPayload buildPrepareActivationPayload(ActivationLayer2Request requestL2,
+                                                       GetApplicationDetailResponse applicationDetail) throws Exception {
+
+        // Set parameters
+        final String applicationKey = applicationDetail.getVersions().get(0).getApplicationKey();
+        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, this.version, applicationKey, null);
+        final Long timestamp = new Date().getTime();
+        final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
+        final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
+
+        final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(
+                Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
+
+        // Encrypt payload
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new ObjectMapper().writeValue(baos, requestL2);
+        EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey,
+                applicationDetail.getVersions().get(0).getApplicationSecret().getBytes(StandardCharsets.UTF_8),
+                EciesSharedInfo1.ACTIVATION_LAYER_2, eciesParameters);
+        return eciesEncryptor.encrypt(baos.toByteArray(), eciesParameters);
+    }
+
+    private InitActivationResponse initActivation(String applicationId) throws Exception {
+        String userId = UUID.randomUUID().toString();
+        return tested.initActivation(
+                applicationId, userId,
+                null, null, null,null,null,
+                this.keyConvertor);
+    }
+
+    private GetApplicationDetailResponse createApplication() throws Exception {
         String testId = UUID.randomUUID().toString();
         CreateApplicationRequest createApplicationRequest = new CreateApplicationRequest();
         createApplicationRequest.setApplicationId(testId);
         CreateApplicationResponse createApplicationResponse = powerAuthService.createApplication(createApplicationRequest);
 
-        CreateApplicationVersionRequest createApplicationVersionRequest = new CreateApplicationVersionRequest();
-        createApplicationVersionRequest.setApplicationId(createApplicationResponse.getApplicationId());
-        createApplicationVersionRequest.setApplicationVersionId("test");
-        CreateApplicationVersionResponse createApplicationVersionResponse = powerAuthService.createApplicationVersion(createApplicationVersionRequest);
-
         GetApplicationDetailRequest detailRequest = new GetApplicationDetailRequest();
         detailRequest.setApplicationId(createApplicationResponse.getApplicationId());
-        GetApplicationDetailResponse detailResponse = powerAuthService.getApplicationDetail(detailRequest);
-
-        ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
-
-        // Build Request; omit devicePublicKey for this test
-        // other attributes have logic based on null value or are optional
-        ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-
-        final String version = "3.2";
-        String activationCode = "AAAAA-BBBBB-CCCCC-DDDDD";
-        boolean shouldGenerateRecoveryCodes = false;
-        final String applicationKey = createApplicationVersionResponse.getApplicationKey();
-        final byte[] associatedData = EciesUtils.deriveAssociatedData(EciesScope.APPLICATION_SCOPE, version, applicationKey, null);
-        final Long timestamp = new Date().getTime();
-        final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
-        final EciesParameters eciesParameters = EciesParameters.builder().nonce(nonceBytes).associatedData(associatedData).timestamp(timestamp).build();
-
-        EciesEncryptor eciesEncryptor = new EciesFactory().getEciesEncryptorForApplication(masterPublicKey,
-                createApplicationVersionResponse.getApplicationSecret().getBytes(StandardCharsets.UTF_8),
-                EciesSharedInfo1.ACTIVATION_LAYER_2, eciesParameters);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new ObjectMapper().writeValue(baos, requestL2);
-        EciesPayload eciesPayload = eciesEncryptor.encrypt(baos.toByteArray(), eciesParameters);
-
-
-        Executable executable = () -> tested.prepareActivation(activationCode, applicationKey,
-                shouldGenerateRecoveryCodes, eciesPayload, version, this.keyConvertor);
-        GenericServiceException exception = assertThrows(GenericServiceException.class, executable);
-        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
+        return powerAuthService.getApplicationDetail(detailRequest);
     }
 
 }

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -70,7 +70,7 @@ public class ActivationServiceBehaviorTest {
     private final String version = "3.2";
 
     @Test
-    public void testPrepareActivationWithValidPayload() throws Exception {
+    void testPrepareActivationWithValidPayload() throws Exception {
 
         // Create application
         final GetApplicationDetailResponse detailResponse = this.createApplication();
@@ -100,7 +100,7 @@ public class ActivationServiceBehaviorTest {
     }
 
     @Test
-    public void testPrepareActivationWithInvalidPayload() throws Exception {
+    void testPrepareActivationWithInvalidPayload() throws Exception {
 
         // Create application
         final GetApplicationDetailResponse detailResponse = this.createApplication();

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -57,8 +57,10 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Jan Pesek, janpesek@outlook.com
  */
+/*
 @SpringBootTest
 @Transactional
+*/
 class ActivationServiceBehaviorTest {
 /*
     @Autowired


### PR DESCRIPTION
The encrypted payload represents ActivationLayer2Request.class, which contains:

- devicePublicKey (expected)
- activationOtp, platform (have logic based on null value later)
- non-specific activationName, extras, deviceInfo

Test case was created to replicate the issue and the issue was solved by checking of presence of the devicePublicKey, which is the only attribute passed directly to a method without being checked. 