### PR TITLE
Fix #1100: Application check in update callback api

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehavior.java
@@ -154,8 +154,8 @@ public class CallbackUrlBehavior {
         }
 
         final Optional<CallbackUrlEntity> entityOptional = callbackUrlRepository.findById(request.getId());
-        if (entityOptional.isEmpty()) {
-            logger.warn("Invalid callback ID: "+request.getId());
+        if (entityOptional.isEmpty() || !request.getApplicationId().equals(entityOptional.get().getApplication().getId())) {
+            logger.warn("Invalid callback ID: {}", request.getId());
             // Rollback is not required, error occurs before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
         }
@@ -164,7 +164,7 @@ public class CallbackUrlBehavior {
         try {
             new URL(request.getCallbackUrl());
         } catch (MalformedURLException e) {
-            logger.warn("Invalid callback URL: "+request.getCallbackUrl());
+            logger.warn("Invalid callback URL: {}", request.getCallbackUrl());
             // Rollback is not required, error occurs before writing to database
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_URL_FORMAT);
         }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehavior.java
@@ -153,8 +153,7 @@ public class CallbackUrlBehavior {
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
         }
 
-        final Optional<CallbackUrlEntity> entityOptional = callbackUrlRepository.findById(request.getId());
-        final CallbackUrlEntity entity = entityOptional
+        final CallbackUrlEntity entity = callbackUrlRepository.findById(request.getId())
                 .filter(it -> it.getApplication().getId().equals(request.getApplicationId()))
                 .orElseThrow(() -> {
                     // Rollback is not required, error occurs before writing to database

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.java
@@ -1,0 +1,105 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.server.service.behavior.tasks;
+
+import com.wultra.security.powerauth.client.model.request.UpdateCallbackUrlRequest;
+import io.getlime.security.powerauth.app.server.database.model.entity.CallbackUrlEntity;
+import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import io.getlime.security.powerauth.app.server.service.model.ServiceError;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test for {@link CallbackUrlBehavior}.
+ *
+ * @author Jan Pesek, janpesek@outlook.com
+ */
+@SpringBootTest
+@Sql
+@Transactional
+class CallbackUrlBehaviorTest {
+
+    @Autowired
+    private CallbackUrlBehavior tested;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void updateCallbackUrlTest() throws Exception {
+        CallbackUrlEntity callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
+        assertEquals("PA_Tests", callbackUrl.getApplication().getId());
+        assertEquals("test-callback", callbackUrl.getName());
+
+        final UpdateCallbackUrlRequest request = new UpdateCallbackUrlRequest();
+        request.setApplicationId("PA_Tests");
+        request.setId("cafec169-28a6-490c-a1d5-c012b9e3c044");
+        request.setCallbackUrl("http://localhost:8080");
+        request.setAuthentication(null);
+        request.setName("new-name");
+        tested.updateCallbackUrl(request);
+
+        callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
+        assertEquals("PA_Tests", callbackUrl.getApplication().getId());
+        assertEquals("new-name", callbackUrl.getName());
+    }
+
+    @Test
+    void updateCallbackUrlInvalidCallbackId() throws Exception {
+        final CallbackUrlEntity callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
+        assertEquals("PA_Tests", callbackUrl.getApplication().getId());
+        assertEquals("test-callback", callbackUrl.getName());
+
+        final UpdateCallbackUrlRequest request = new UpdateCallbackUrlRequest();
+        request.setApplicationId(callbackUrl.getApplication().getId());
+        request.setCallbackUrl(callbackUrl.getCallbackUrl());
+        request.setAuthentication(null);
+        request.setName("new-name");
+        request.setId(UUID.randomUUID().toString());
+
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> tested.updateCallbackUrl(request));
+        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
+    }
+
+    @Test
+    void updateCallbackUrlInvalidApplicationId() {
+        final CallbackUrlEntity callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
+        assertEquals("PA_Tests", callbackUrl.getApplication().getId());
+        assertEquals("test-callback", callbackUrl.getName());
+
+        final UpdateCallbackUrlRequest request = new UpdateCallbackUrlRequest();
+        request.setId(callbackUrl.getId());
+        request.setCallbackUrl(callbackUrl.getCallbackUrl());
+        request.setAuthentication(null);
+        request.setName("new-name");
+        request.setApplicationId("Unknown-App");
+
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> tested.updateCallbackUrl(request));
+        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
+    }
+
+}

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.java
@@ -51,7 +51,7 @@ class CallbackUrlBehaviorTest {
 
     @Test
     void updateCallbackUrlTest() throws Exception {
-        CallbackUrlEntity callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
+        final CallbackUrlEntity callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
         assertEquals("PA_Tests", callbackUrl.getApplication().getId());
         assertEquals("test-callback", callbackUrl.getName());
 
@@ -63,9 +63,9 @@ class CallbackUrlBehaviorTest {
         request.setName("new-name");
         tested.updateCallbackUrl(request);
 
-        callbackUrl = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
-        assertEquals("PA_Tests", callbackUrl.getApplication().getId());
-        assertEquals("new-name", callbackUrl.getName());
+        final CallbackUrlEntity updated = entityManager.find(CallbackUrlEntity.class, "cafec169-28a6-490c-a1d5-c012b9e3c044");
+        assertEquals("PA_Tests", updated.getApplication().getId());
+        assertEquals("new-name", updated.getName());
     }
 
     @Test

--- a/powerauth-java-server/src/test/resources/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.sql
+++ b/powerauth-java-server/src/test/resources/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.sql
@@ -1,0 +1,5 @@
+INSERT INTO pa_application (id, name) VALUES
+    (21, 'PA_Tests');
+
+INSERT INTO pa_application_callback (id, application_id, name, callback_url, type) VALUES
+    ('cafec169-28a6-490c-a1d5-c012b9e3c044', 21, 'test-callback', 'http://localhost:8080', 'ACTIVATION_STATUS_CHANGE');


### PR DESCRIPTION
Fix #1100:
If `applicationId` from the request does not match the `applicationId` paired with the callback, behave like the callback does not exist at all.