### PR TITLE
Fix #832: Allow shorter OTP for offline signatures (backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <spring-cloud-vault.version>3.1.1</spring-cloud-vault.version>
 
         <!-- PowerAuth Dependencies -->
-        <powerauth-java-crypto.version>1.5.0-SNAPSHOT</powerauth-java-crypto.version>
+        <powerauth-java-crypto.version>1.4.0</powerauth-java-crypto.version>
         <powerauth-rest-base.version>1.6.0</powerauth-rest-base.version>
         <powerauth-audit-base.version>1.6.0</powerauth-audit-base.version>
         <bcprov-jdk18on.version>1.72</bcprov-jdk18on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <spring-cloud-vault.version>3.1.1</spring-cloud-vault.version>
 
         <!-- PowerAuth Dependencies -->
-        <powerauth-java-crypto.version>1.4.0</powerauth-java-crypto.version>
+        <powerauth-java-crypto.version>1.5.0-SNAPSHOT</powerauth-java-crypto.version>
         <powerauth-rest-base.version>1.6.0</powerauth-rest-base.version>
         <powerauth-audit-base.version>1.6.0</powerauth-audit-base.version>
         <bcprov-jdk18on.version>1.72</bcprov-jdk18on.version>

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -149,6 +149,14 @@ public class PowerAuthServiceConfiguration {
     private long signatureValidationLookahead;
 
     /**
+     * When validating the offline (or decimalized) signature, how many digits should a factor-related component have.
+     */
+    @Value("${powerauth.service.crypto.offlineSignatureComponentLength}")
+    @Min(4)
+    @Max(8)
+    private int offlineSignatureComponentLength;
+
+    /**
      * Whether HTTP proxy is enabled for outgoing HTTP requests.
      */
     @Value("${powerauth.service.http.proxy.enabled}")
@@ -452,6 +460,22 @@ public class PowerAuthServiceConfiguration {
      */
     public void setSignatureValidationLookahead(long signatureValidationLookahead) {
         this.signatureValidationLookahead = signatureValidationLookahead;
+    }
+
+    /**
+     * Get offline signature factor-related component length.
+     * @return Factor-related component length.
+     */
+    public int getOfflineSignatureComponentLength() {
+        return offlineSignatureComponentLength;
+    }
+
+    /**
+     * Set offline signature factor-related component length.
+     * @param offlineSignatureComponentLength Factor-related component length.
+     */
+    public void setOfflineSignatureComponentLength(int offlineSignatureComponentLength) {
+        this.offlineSignatureComponentLength = offlineSignatureComponentLength;
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/OfflineSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/OfflineSignatureServiceBehavior.java
@@ -37,6 +37,8 @@ import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.signature.OfflineSignatureRequest;
 import io.getlime.security.powerauth.app.server.service.model.signature.SignatureData;
 import io.getlime.security.powerauth.app.server.service.model.signature.SignatureResponse;
+import io.getlime.security.powerauth.crypto.lib.config.DecimalSignatureConfiguration;
+import io.getlime.security.powerauth.crypto.lib.config.SignatureConfiguration;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureFormat;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
@@ -96,19 +98,20 @@ public class OfflineSignatureServiceBehavior {
     /**
      * Verify signature for given activation and provided data in offline mode. Log every validation attempt in the audit log.
      *
-     * @param activationId           Activation ID.
-     * @param signatureTypes         Signature types to try to use during verification of offline signature.
-     * @param signature              Provided signature.
-     * @param dataString             String with data used to compute the signature.
-     * @param keyConversionUtilities Conversion utility class.
+     * @param activationId              Activation ID.
+     * @param signatureTypes            Signature types to try to use during verification of offline signature.
+     * @param signature                 Provided signature.
+     * @param dataString                String with data used to compute the signature.
+     * @param expectedComponentLength   Expected length of the signature factor component.
+     * @param keyConversionUtilities    Conversion utility class.
      * @return Response with the signature validation result object.
      * @throws GenericServiceException In case server private key decryption fails.
      */
     public VerifyOfflineSignatureResponse verifyOfflineSignature(String activationId, List<SignatureType> signatureTypes, String signature, KeyValueMap additionalInfo,
-                                                                 String dataString, KeyConvertor keyConversionUtilities)
+                                                                 String dataString, Integer expectedComponentLength, KeyConvertor keyConversionUtilities)
             throws GenericServiceException {
         try {
-            return verifyOfflineSignatureImpl(activationId, signatureTypes, signature, additionalInfo, dataString, keyConversionUtilities);
+            return verifyOfflineSignatureImpl(activationId, signatureTypes, signature, additionalInfo, dataString, expectedComponentLength, keyConversionUtilities);
         } catch (InvalidKeySpecException | InvalidKeyException ex) {
             logger.error(ex.getMessage(), ex);
             // Rollback is not required, cryptography methods are executed before database is used for writing
@@ -261,6 +264,7 @@ public class OfflineSignatureServiceBehavior {
      * @param signature Signature.
      * @param additionalInfo Additional information related to signature verification.
      * @param dataString Signature data.
+     * @param expectedComponentLength Expected length of the signature factor component.
      * @param keyConversionUtilities Key convertor.
      * @return Verify offline signature response.
      * @throws InvalidKeySpecException In case a key specification is invalid.
@@ -270,7 +274,7 @@ public class OfflineSignatureServiceBehavior {
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     private VerifyOfflineSignatureResponse verifyOfflineSignatureImpl(String activationId, List<SignatureType> signatureTypes, String signature, KeyValueMap additionalInfo,
-                                                                      String dataString, KeyConvertor keyConversionUtilities)
+                                                                      String dataString, Integer expectedComponentLength, KeyConvertor keyConversionUtilities)
             throws InvalidKeySpecException, InvalidKeyException, GenericServiceException, GenericCryptoException, CryptoProviderException {
         // Prepare current timestamp in advance
         final Date currentTimestamp = new Date();
@@ -283,7 +287,11 @@ public class OfflineSignatureServiceBehavior {
 
             // Application secret is "offline" in offline mode
             final byte[] data = (dataString + "&" + APPLICATION_SECRET_OFFLINE_MODE).getBytes(StandardCharsets.UTF_8);
-            final SignatureData signatureData = new SignatureData(data, signature, PowerAuthSignatureFormat.DECIMAL, null, additionalInfo, null);
+            final DecimalSignatureConfiguration signatureConfiguration = SignatureConfiguration.decimal();
+            if (expectedComponentLength != null) {
+                signatureConfiguration.setLength(expectedComponentLength);
+            }
+            final SignatureData signatureData = new SignatureData(data, signature, signatureConfiguration, null, additionalInfo, null);
             final OfflineSignatureRequest offlineSignatureRequest = new OfflineSignatureRequest(signatureData, signatureTypes);
 
             if (activation.getActivationStatus() == ActivationStatus.ACTIVE) {

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/OnlineSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/OnlineSignatureServiceBehavior.java
@@ -31,6 +31,7 @@ import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import io.getlime.security.powerauth.app.server.service.model.signature.OnlineSignatureRequest;
 import io.getlime.security.powerauth.app.server.service.model.signature.SignatureData;
 import io.getlime.security.powerauth.app.server.service.model.signature.SignatureResponse;
+import io.getlime.security.powerauth.crypto.lib.config.SignatureConfiguration;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureFormat;
 import io.getlime.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -143,6 +144,7 @@ public class OnlineSignatureServiceBehavior {
 
             // Convert signature version to expected signature format.
             final PowerAuthSignatureFormat signatureFormat = PowerAuthSignatureFormat.getFormatForSignatureVersion(signatureVersion);
+            final SignatureConfiguration signatureConfiguration = SignatureConfiguration.forFormat(signatureFormat);
 
             // Check the activation - application relationship and version support
             final ApplicationVersionEntity applicationVersion = repositoryCatalogue.getApplicationVersionRepository().findByApplicationKey(applicationKey);
@@ -151,7 +153,7 @@ public class OnlineSignatureServiceBehavior {
                 logger.warn("Application version is incorrect, application key: {}", applicationKey);
                 // Get the data and append application KEY in this case, just for auditing reasons
                 final byte[] data = (dataString + "&" + applicationKey).getBytes(StandardCharsets.UTF_8);
-                final SignatureData signatureData = new SignatureData(data, signature, signatureFormat, signatureVersion, additionalInfo, forcedSignatureVersion);
+                final SignatureData signatureData = new SignatureData(data, signature, signatureConfiguration, signatureVersion, additionalInfo, forcedSignatureVersion);
                 final OnlineSignatureRequest signatureRequest = new OnlineSignatureRequest(signatureData, signatureType);
                 signatureSharedServiceBehavior.handleInvalidApplicationVersion(activation, signatureRequest, currentTimestamp);
 
@@ -160,7 +162,7 @@ public class OnlineSignatureServiceBehavior {
             }
 
             final byte[] data = (dataString + "&" + applicationVersion.getApplicationSecret()).getBytes(StandardCharsets.UTF_8);
-            final SignatureData signatureData = new SignatureData(data, signature, signatureFormat, signatureVersion, additionalInfo, forcedSignatureVersion);
+            final SignatureData signatureData = new SignatureData(data, signature, signatureConfiguration, signatureVersion, additionalInfo, forcedSignatureVersion);
             final OnlineSignatureRequest signatureRequest = new OnlineSignatureRequest(signatureData, signatureType);
 
             if (activation.getActivationStatus() == ActivationStatus.ACTIVE) {

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/SignatureSharedServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/v3/SignatureSharedServiceBehavior.java
@@ -326,7 +326,7 @@ public class SignatureSharedServiceBehavior {
                 final PowerAuthSignatureTypes powerAuthSignatureTypes = signatureTypeConverter.convertFrom(signatureType);
                 final List<SecretKey> signatureKeys = powerAuthServerKeyFactory.keysForSignatureType(powerAuthSignatureTypes, masterSecretKey);
 
-                signatureValid = powerAuthServerSignature.verifySignatureForData(signatureData.getData(), signatureData.getSignature(), signatureKeys, ctrData, signatureData.getSignatureFormat());
+                signatureValid = powerAuthServerSignature.verifySignatureForData(signatureData.getData(), signatureData.getSignature(), signatureKeys, ctrData, signatureData.getSignatureConfiguration());
                 if (signatureValid) {
                     // Set the next valid value of numeric counter based on current iteration counter +1
                     ctrNext = iteratedCounter + 1;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/signature/SignatureData.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/model/signature/SignatureData.java
@@ -18,7 +18,7 @@
 package io.getlime.security.powerauth.app.server.service.model.signature;
 
 import com.wultra.security.powerauth.client.v3.KeyValueMap;
-import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureFormat;
+import io.getlime.security.powerauth.crypto.lib.config.SignatureConfiguration;
 
 /**
  * Data related to both online and offline signatures.
@@ -30,7 +30,7 @@ public class SignatureData {
     private byte[] data;
     private String signature;
     private String signatureVersion;
-    private PowerAuthSignatureFormat signatureFormat;
+    private SignatureConfiguration signatureConfiguration;
     private KeyValueMap additionalInfo;
     private Integer forcedSignatureVersion;
 
@@ -41,19 +41,19 @@ public class SignatureData {
     }
 
     /**
-     * Signature data constructur.
+     * Signature data constructor.
      * @param data Signed data.
      * @param signature Data signature.
-     * @param signatureFormat Format of signature
+     * @param signatureConfiguration Format of signature with associated parameters.
      * @param signatureVersion Version of requested signature
      * @param additionalInfo Additional information related to the signature.
      * @param forcedSignatureVersion Forced signature version during upgrade.
      */
-    public SignatureData(byte[] data, String signature, PowerAuthSignatureFormat signatureFormat, String signatureVersion, KeyValueMap additionalInfo, Integer forcedSignatureVersion) {
+    public SignatureData(byte[] data, String signature, SignatureConfiguration signatureConfiguration, String signatureVersion, KeyValueMap additionalInfo, Integer forcedSignatureVersion) {
         this.data = data;
         this.signature = signature;
         this.signatureVersion = signatureVersion;
-        this.signatureFormat = signatureFormat;
+        this.signatureConfiguration = signatureConfiguration;
         this.additionalInfo = additionalInfo;
         this.forcedSignatureVersion = forcedSignatureVersion;
     }
@@ -83,11 +83,11 @@ public class SignatureData {
     }
 
     /**
-     * Get signature format.
-     * @return Signature format.
+     * Get signature configuration.
+     * @return Signature configuration.
      */
-    public PowerAuthSignatureFormat getSignatureFormat() {
-        return signatureFormat;
+    public SignatureConfiguration getSignatureConfiguration() {
+        return signatureConfiguration;
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/v3/PowerAuthServiceImpl.java
@@ -41,6 +41,7 @@ import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.util.*;
 
 /**
@@ -483,6 +484,7 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             final String activationId = request.getActivationId();
             final String data = request.getData();
             final String signature = request.getSignature();
+            final BigInteger componentLength = request.getComponentLength();
             final List<SignatureType> allowedSignatureTypes = new ArrayList<>();
             // The order of signature types is important. PowerAuth server logs first found signature type
             // as used signature type in case signature verification fails. In case the POSSESSION_BIOMETRY signature
@@ -491,9 +493,10 @@ public class PowerAuthServiceImpl implements PowerAuthService {
             if (request.isAllowBiometry()) {
                 allowedSignatureTypes.add(SignatureType.POSSESSION_BIOMETRY);
             }
+            final int expectedComponentLength = (componentLength != null) ? componentLength.intValue() : powerAuthServiceConfiguration.getOfflineSignatureComponentLength();
             final KeyValueMap additionalInfo = new KeyValueMap();
             logger.info("VerifyOfflineSignatureRequest received, activation ID: {}", activationId);
-            final VerifyOfflineSignatureResponse response = behavior.getOfflineSignatureServiceBehavior().verifyOfflineSignature(activationId, allowedSignatureTypes, signature, additionalInfo, data, keyConvertor);
+            final VerifyOfflineSignatureResponse response = behavior.getOfflineSignatureServiceBehavior().verifyOfflineSignature(activationId, allowedSignatureTypes, signature, additionalInfo, data, expectedComponentLength, keyConvertor);
             logger.info("VerifyOfflineSignatureRequest succeeded");
             return response;
         } catch (GenericServiceException ex) {

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -65,6 +65,7 @@ powerauth.service.crypto.generateOperationIterations=10
 powerauth.service.crypto.activationValidityInMilliseconds=300000
 powerauth.service.crypto.signatureMaxFailedAttempts=5
 powerauth.service.crypto.signatureValidationLookahead=20
+powerauth.service.crypto.offlineSignatureComponentLength=8
 
 # HTTP Proxy Settings
 powerauth.service.http.proxy.enabled=false

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-3.0.xsd
@@ -740,6 +740,7 @@
                 <xs:element name="activationId" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="data" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="signature" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="componentLength" type="xs:integer" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="allowBiometry" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>

--- a/powerauth-java-server/src/test/resources/application.properties
+++ b/powerauth-java-server/src/test/resources/application.properties
@@ -44,6 +44,7 @@ powerauth.service.crypto.generateOperationIterations=10
 powerauth.service.crypto.activationValidityInMilliseconds=120000
 powerauth.service.crypto.signatureMaxFailedAttempts=5
 powerauth.service.crypto.signatureValidationLookahead=20
+powerauth.service.crypto.offlineSignatureComponentLength=8
 
 # HTTP Proxy Settings
 powerauth.service.http.proxy.enabled=false


### PR DESCRIPTION
Cherry- picked from commit b4b583e149e2aeccc54dacfb8e3547218c146a5c and f704672a695b4da600c7f5974d476bd2bfd25ab0 (fixes test), are predecessors of https://github.com/wultra/powerauth-server/pull/939 backport