### PR TITLE
Fix column name pa_application_config.config_key in db scripts

### DIFF
--- a/docs/db/changelog/changesets/powerauth-java-server/1.7.x/20240212-application-config.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/1.7.x/20240212-application-config.xml
@@ -49,9 +49,9 @@
                 <indexExists tableName="pa_application_config" indexName="pa_app_config_key_idx" />
             </not>
         </preConditions>
-        <comment>Create a new index on pa_application_config(key)</comment>
+        <comment>Create a new index on pa_application_config(config_key)</comment>
         <createIndex tableName="pa_application_config" indexName="pa_app_config_key_idx">
-            <column name="key" />
+            <column name="config_key" />
         </createIndex>
     </changeSet>
 

--- a/docs/sql/mssql/migration_1.6.0_1.7.0.sql
+++ b/docs/sql/mssql/migration_1.6.0_1.7.0.sql
@@ -18,8 +18,8 @@ CREATE TABLE pa_application_config (id int NOT NULL, application_id int NOT NULL
 GO
 
 -- Changeset powerauth-java-server/1.7.x/20240212-application-config.xml::2::Roman Strobl
--- Create a new index on pa_application_config(key)
-CREATE NONCLUSTERED INDEX pa_app_config_key_idx ON pa_application_config([key]);
+-- Create a new index on pa_application_config(config_key)
+CREATE NONCLUSTERED INDEX pa_app_config_key_idx ON pa_application_config([config_key]);
 GO
 
 -- Changeset powerauth-java-server/1.7.x/20240212-application-config.xml::3::Lubos Racansky

--- a/docs/sql/oracle/migration_1.6.0_1.7.0.sql
+++ b/docs/sql/oracle/migration_1.6.0_1.7.0.sql
@@ -14,8 +14,8 @@ ALTER TABLE pa_activation MODIFY extras CLOB;
 CREATE TABLE pa_application_config (id INTEGER NOT NULL, application_id INTEGER NOT NULL, config_key VARCHAR2(255) NOT NULL, config_values CLOB, CONSTRAINT PK_PA_APPLICATION_CONFIG PRIMARY KEY (id), CONSTRAINT pa_app_config_app_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
 
 -- Changeset powerauth-java-server/1.7.x/20240212-application-config.xml::2::Roman Strobl
--- Create a new index on pa_application_config(key)
-CREATE INDEX pa_app_config_key_idx ON pa_application_config(key);
+-- Create a new index on pa_application_config(config_key)
+CREATE INDEX pa_app_config_key_idx ON pa_application_config(config_key);
 
 -- Changeset powerauth-java-server/1.7.x/20240212-application-config.xml::3::Lubos Racansky
 -- Create a new sequence pa_app_conf_seq

--- a/docs/sql/postgresql/migration_1.6.0_1.7.0.sql
+++ b/docs/sql/postgresql/migration_1.6.0_1.7.0.sql
@@ -14,8 +14,8 @@ ALTER TABLE pa_activation ALTER COLUMN extras TYPE TEXT USING (extras::TEXT);
 CREATE TABLE pa_application_config (id INTEGER NOT NULL, application_id INTEGER NOT NULL, config_key VARCHAR(255) NOT NULL, config_values TEXT, CONSTRAINT pa_application_config_pkey PRIMARY KEY (id), CONSTRAINT pa_app_config_app_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
 
 -- Changeset powerauth-java-server/1.7.x/20240212-application-config.xml::2::Roman Strobl
--- Create a new index on pa_application_config(key)
-CREATE INDEX pa_app_config_key_idx ON pa_application_config(key);
+-- Create a new index on pa_application_config(config_key)
+CREATE INDEX pa_app_config_key_idx ON pa_application_config(config_key);
 
 -- Changeset powerauth-java-server/1.7.x/20240212-application-config.xml::3::Lubos Racansky
 -- Create a new sequence pa_app_conf_seq


### PR DESCRIPTION
A follow-up to #1299