### PR TITLE
Fix #1407: Reflect fido2 changes in client model

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/fido2/AllowCredentials.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/fido2/AllowCredentials.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2021 Wultra s.r.o.
+ * Copyright (C) 2024 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -16,28 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.wultra.security.powerauth.client.model.response.fido2;
+package com.wultra.security.powerauth.client.model.entity.fido2;
 
-import com.wultra.security.powerauth.client.model.entity.fido2.AllowCredentials;
 import lombok.Data;
-import lombok.ToString;
 
 import java.util.List;
 
 /**
- * Response for obtaining assertion challenge.
+ * Representation of an allowed authenticator instance.
  *
- * @author Roman Strobl, roman.strobl@wultra.com
+ * @author Jan Pesek, jan.pesek@wultra.com
  */
 @Data
-public class AssertionChallengeResponse {
-
-    private List<String> applicationIds;
-    @ToString.Exclude
-    private String challenge;
-    private String userId;
-    private Long failedAttempts;
-    private Long maxFailedAttempts;
-    private List<AllowCredentials> allowCredentials;
-
+public class AllowCredentials {
+    private byte[] credentialId;
+    private final String type = "public-key";
+    private List<String> transports;
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/fido2/AssertionChallengeRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/fido2/AssertionChallengeRequest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 @Data
 public class AssertionChallengeRequest {
 
+    private String userId;
     @NotEmpty
     private List<@NotBlank String> applicationIds;
     private String externalId;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
@@ -124,7 +124,7 @@ public class PowerAuthAssertionProvider implements AssertionProvider {
             operationApproveRequest.getAdditionalData().putAll(prepareAdditionalData(authenticatorDetail, authenticatorData, clientDataJSON));
             final OperationUserActionResponse approveOperation = serviceBehaviorCatalogue.getOperationBehavior().attemptApproveOperation(operationApproveRequest, (operationEntity, request) -> {
                 @SuppressWarnings("unchecked")
-                final Set<String> allowCredentials = (Set<String>) operationEntity.getAdditionalData().get(ATTR_ALLOW_CREDENTIALS);
+                final List<String> allowCredentials = (List<String>) operationEntity.getAdditionalData().get(ATTR_ALLOW_CREDENTIALS);
                 final String credentialId = (String) request.getAdditionalData().get(ATTR_CREDENTIAL_ID);
                 return allowCredentials == null || allowCredentials.isEmpty() || allowCredentials.contains(credentialId);
             });


### PR DESCRIPTION
Issue https://github.com/wultra/powerauth-server/issues/1374 does not reflect changes made to requests/responses to client model.

There was also an error `ArrayList cannot be cast to class Set` while deserialising additional data to set, which was fixed by using list instead.