### PR TITLE
Fix #1417: FIDO2: Invalid AAGUID format in configuration of fido2_aaguids_allowed

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthRegistrationProvider.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthRegistrationProvider.java
@@ -41,10 +41,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.wultra.powerauth.fido2.rest.model.enumeration.Fido2ConfigKeys.CONFIG_KEY_ALLOWED_AAGUIDS;
 import static com.wultra.powerauth.fido2.rest.model.enumeration.Fido2ConfigKeys.CONFIG_KEY_ALLOWED_ATTESTATION_FMT;
@@ -159,7 +161,7 @@ public class PowerAuthRegistrationProvider implements RegistrationProvider {
         final GetApplicationConfigRequest configRequest = new GetApplicationConfigRequest();
         configRequest.setApplicationId(applicationId);
         final GetApplicationConfigResponse configResponse = configService.getApplicationConfig(configRequest);
-        final String aaguidStr = new String(aaguid, StandardCharsets.UTF_8);
+        final String aaguidStr = bytesToUUID(aaguid).toString();
         Optional<ApplicationConfigurationItem> configFmt = configResponse.getApplicationConfigs().stream()
                 .filter(cfg -> CONFIG_KEY_ALLOWED_ATTESTATION_FMT.equals(cfg.getKey()))
                 .findFirst();
@@ -192,5 +194,15 @@ public class PowerAuthRegistrationProvider implements RegistrationProvider {
         }
 
         return true;
+    }
+
+    private UUID bytesToUUID(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        final ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+        long mostSigBits = byteBuffer.getLong();
+        long leastSigBits = byteBuffer.getLong();
+        return new UUID(mostSigBits, leastSigBits);
     }
 }

--- a/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/Fido2AuthenticatorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/Fido2AuthenticatorTest.java
@@ -309,7 +309,7 @@ class Fido2AuthenticatorTest {
         final CreateApplicationConfigRequest requestCreate = new CreateApplicationConfigRequest();
         requestCreate.setApplicationId(APPLICATION_ID);
         requestCreate.setKey(CONFIG_KEY_ALLOWED_AAGUIDS);
-        requestCreate.setValues(List.of("\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001"));
+        requestCreate.setValues(List.of("00000000-0000-0000-0000-000000000001"));
         powerAuthService.createApplicationConfig(requestCreate);
 
         // Registration should fail
@@ -328,7 +328,7 @@ class Fido2AuthenticatorTest {
         final CreateApplicationConfigRequest requestCreate = new CreateApplicationConfigRequest();
         requestCreate.setApplicationId(APPLICATION_ID);
         requestCreate.setKey(CONFIG_KEY_ALLOWED_AAGUIDS);
-        requestCreate.setValues(List.of("\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"));
+        requestCreate.setValues(List.of("00000000-0000-0000-0000-000000000000"));
         powerAuthService.createApplicationConfig(requestCreate);
 
         // Registration should succeed


### PR DESCRIPTION
I switched the AAGUID configuration to UUID, it was incorrectly expected as raw bytes.