### PR TITLE
Fix #1425: FIDO2: Return operation data in a separate allowCredential item

### DIFF
--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverter.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverter.java
@@ -26,7 +26,6 @@ import com.wultra.powerauth.fido2.rest.model.request.AssertionChallengeRequest;
 import com.wultra.powerauth.fido2.rest.model.response.AssertionChallengeResponse;
 import com.wultra.security.powerauth.client.model.request.OperationCreateRequest;
 import com.wultra.security.powerauth.client.model.response.OperationDetailResponse;
-import io.getlime.security.powerauth.crypto.lib.util.ByteUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -126,7 +125,7 @@ public class AssertionChallengeConverter {
                 allowCredentials.add(ac);
             }
             if (hasWultraModel) {
-                final byte[] credentialId = source.getData().getBytes(StandardCharsets.UTF_8);
+                final byte[] credentialId = Base64.getEncoder().encode(source.getData().getBytes(StandardCharsets.UTF_8));
                 final AllowCredentials ac = new AllowCredentials();
                 ac.setCredentialId(credentialId);
                 ac.setTransports(Collections.emptyList());


### PR DESCRIPTION
Added Base64 encoding for the operation data.