### PR TITLE
Fix #1436: FIDO test app Opera browser - authenticatorAttachment error

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/fido2/AuthenticatorParameters.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/fido2/AuthenticatorParameters.java
@@ -36,7 +36,6 @@ public class AuthenticatorParameters {
     private String credentialId;
     @NotBlank
     private String type;
-    @NotBlank
     private String authenticatorAttachment;
     private AuthenticatorAttestationResponse response = new AuthenticatorAttestationResponse();
     @NotBlank

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/fido2/AssertionVerificationRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/fido2/AssertionVerificationRequest.java
@@ -39,7 +39,6 @@ public class AssertionVerificationRequest {
     private String credentialId;
     @NotBlank
     private String type;
-    @NotBlank
     private String authenticatorAttachment;
     private AuthenticatorAssertionResponse response = new AuthenticatorAssertionResponse();
     @NotBlank

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/fido2/RegistrationRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/fido2/RegistrationRequest.java
@@ -19,6 +19,7 @@
 package com.wultra.security.powerauth.client.model.request.fido2;
 
 import com.wultra.security.powerauth.client.model.entity.fido2.AuthenticatorParameters;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -36,6 +37,7 @@ public class RegistrationRequest {
     private String expectedChallenge;
 
     // Authenticator parameters
+    @Valid
     private AuthenticatorParameters authenticatorParameters;
 
 

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/AuthenticatorParameters.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/AuthenticatorParameters.java
@@ -38,7 +38,6 @@ public class AuthenticatorParameters {
     private String credentialId;
     @NotBlank
     private String type;
-    @NotBlank
     private String authenticatorAttachment;
     private AuthenticatorAttestationResponse response = new AuthenticatorAttestationResponse();
     @NotBlank

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/request/AssertionVerificationRequest.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/request/AssertionVerificationRequest.java
@@ -39,7 +39,6 @@ public class AssertionVerificationRequest {
     private String credentialId;
     @NotBlank
     private String type;
-    @NotBlank
     private String authenticatorAttachment;
     private AuthenticatorAssertionResponse response = new AuthenticatorAssertionResponse();
     @NotBlank

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/request/RegistrationRequest.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/request/RegistrationRequest.java
@@ -19,6 +19,7 @@
 package com.wultra.powerauth.fido2.rest.model.request;
 
 import com.wultra.powerauth.fido2.rest.model.entity.AuthenticatorParameters;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -38,5 +39,6 @@ public class RegistrationRequest {
     private String expectedChallenge;
 
     // Authenticator parameters
+    @Valid
     private AuthenticatorParameters authenticatorParameters;
 }


### PR DESCRIPTION
Although I found this in [level 3 spec](https://w3c.github.io/webauthn/#iface-pkcredential) only, the `authenticatorAttachment` can be null in both ceremonies. Which is also supported by the [taken test](https://github.com/wultra/powerauth-server/issues/1436).

This test also found out there was missing a cascade validation of parameters class in registration request and so the nested validation annotations were without effect.