### PR TITLE
Fix #1502: FIDO2: Return excludeCredentials in RegistrationChallenge

### DIFF
--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/entity/Credential.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/entity/Credential.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Representation of an allowed authenticator instance.
+ * Representation of a FIDO2 Credential.
  *
  * @author Jan Pesek, jan.pesek@wultra.com
  */

--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/entity/Credential.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/entity/Credential.java
@@ -34,7 +34,7 @@ import java.util.List;
 @ToString
 @Builder
 @Jacksonized
-public class AllowCredentials {
+public class Credential {
 
     private final byte[] credentialId;
 

--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/response/AssertionChallengeResponse.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/response/AssertionChallengeResponse.java
@@ -18,7 +18,7 @@
 
 package com.wultra.security.powerauth.fido2.model.response;
 
-import com.wultra.security.powerauth.fido2.model.entity.AllowCredentials;
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import lombok.Data;
 import lombok.ToString;
 
@@ -38,6 +38,6 @@ public class AssertionChallengeResponse {
     private String userId;
     private Long failedAttempts;
     private Long maxFailedAttempts;
-    private List<AllowCredentials> allowCredentials;
+    private List<Credential> allowCredentials;
 
 }

--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/response/RegistrationChallengeResponse.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/response/RegistrationChallengeResponse.java
@@ -18,8 +18,11 @@
 
 package com.wultra.security.powerauth.fido2.model.response;
 
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import lombok.Data;
 import lombok.ToString;
+
+import java.util.List;
 
 /**
  * @author Roman Strobl, roman.strobl@wultra.com
@@ -32,5 +35,6 @@ public class RegistrationChallengeResponse {
     @ToString.Exclude
     private String challenge;
     private String userId;
+    private List<Credential> excludeCredentials;
 
 }

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverter.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverter.java
@@ -21,7 +21,7 @@ package com.wultra.powerauth.fido2.rest.model.converter;
 import com.wultra.powerauth.fido2.service.model.Fido2DefaultAuthenticators;
 import com.wultra.security.powerauth.client.model.request.OperationCreateRequest;
 import com.wultra.security.powerauth.client.model.response.OperationDetailResponse;
-import com.wultra.security.powerauth.fido2.model.entity.AllowCredentials;
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import com.wultra.powerauth.fido2.rest.model.entity.AssertionChallenge;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
 import com.wultra.security.powerauth.fido2.model.request.AssertionChallengeRequest;
@@ -108,7 +108,7 @@ public class AssertionChallengeConverter {
         destination.setMaxFailedAttempts(source.getMaxFailureCount());
 
         if (authenticatorDetails != null && !authenticatorDetails.isEmpty()) {
-            final List<AllowCredentials> allowCredentials = new ArrayList<>();
+            final List<Credential> allowCredentials = new ArrayList<>();
             for (AuthenticatorDetail ad: authenticatorDetails) {
 
                 @SuppressWarnings("unchecked")
@@ -121,11 +121,11 @@ public class AssertionChallengeConverter {
                     credentialId = ByteUtils.concat(credentialId, operationDataBytes);
                 }
 
-                final AllowCredentials ac = AllowCredentials.builder()
+                final Credential credential = Credential.builder()
                         .credentialId(credentialId)
                         .transports(transports)
                         .build();
-                allowCredentials.add(ac);
+                allowCredentials.add(credential);
             }
             destination.setAllowCredentials(allowCredentials);
         }

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/RegistrationChallengeConverter.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/RegistrationChallengeConverter.java
@@ -19,9 +19,14 @@
 package com.wultra.powerauth.fido2.rest.model.converter;
 
 import com.wultra.powerauth.fido2.rest.model.entity.RegistrationChallenge;
+import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import com.wultra.security.powerauth.fido2.model.response.RegistrationChallengeResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.List;
 
 /**
  * @author Petr Dvorak, petr@wultra.com
@@ -45,7 +50,19 @@ public class RegistrationChallengeConverter {
         destination.setActivationId(source.getActivationId());
         destination.setApplicationId(source.getApplicationId());
         destination.setChallenge(source.getChallenge());
+        destination.setExcludeCredentials(source.getExcludeCredentials());
         return destination;
+    }
+
+    public static Credential toCredentialDescriptor(final AuthenticatorDetail authenticatorDetail) {
+        @SuppressWarnings("unchecked")
+        final List<String> transports = (List<String>) authenticatorDetail.getExtras().get("transports");
+        final byte[] credentialId = Base64.getDecoder().decode(authenticatorDetail.getCredentialId());
+
+        return Credential.builder()
+                .credentialId(credentialId)
+                .transports(transports)
+                .build();
     }
 
 }

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/AssertionChallenge.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/AssertionChallenge.java
@@ -18,7 +18,7 @@
 
 package com.wultra.powerauth.fido2.rest.model.entity;
 
-import com.wultra.security.powerauth.fido2.model.entity.AllowCredentials;
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import lombok.Data;
 
 import java.util.List;
@@ -36,6 +36,6 @@ public class AssertionChallenge {
     private String userId;
     private Long failedAttempts;
     private Long maxFailedAttempts;
-    private List<AllowCredentials> allowCredentials;
+    private List<Credential> allowCredentials;
 
 }

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/RegistrationChallenge.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/RegistrationChallenge.java
@@ -18,7 +18,10 @@
 
 package com.wultra.powerauth.fido2.rest.model.entity;
 
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import lombok.Data;
+
+import java.util.List;
 
 /**
  * Model class representing registration challenge.
@@ -31,4 +34,5 @@ public class RegistrationChallenge {
     private String applicationId;
     private String challenge;
     private String userId;
+    private List<Credential> excludeCredentials;
 }

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverterTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverterTest.java
@@ -20,7 +20,7 @@ package com.wultra.powerauth.fido2.rest.model.converter;
 
 import com.wultra.security.powerauth.client.model.request.OperationCreateRequest;
 import com.wultra.security.powerauth.client.model.response.OperationDetailResponse;
-import com.wultra.security.powerauth.fido2.model.entity.AllowCredentials;
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import com.wultra.powerauth.fido2.rest.model.entity.AssertionChallenge;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
 import com.wultra.security.powerauth.fido2.model.request.AssertionChallengeRequest;
@@ -121,7 +121,7 @@ class AssertionChallengeConverterTest {
         assertEquals(5L, assertionChallenge.getMaxFailedAttempts());
 
         assertNotNull(assertionChallenge.getAllowCredentials());
-        final AllowCredentials allowCredential = assertionChallenge.getAllowCredentials().get(0);
+        final Credential allowCredential = assertionChallenge.getAllowCredentials().get(0);
         assertArrayEquals("credential-1".getBytes(), allowCredential.getCredentialId());
         assertEquals("hybrid", allowCredential.getTransports().get(0));
         assertEquals("public-key", allowCredential.getType());
@@ -154,7 +154,7 @@ class AssertionChallengeConverterTest {
 
         assertNotNull(assertionChallenge.getAllowCredentials());
         assertEquals(1, assertionChallenge.getAllowCredentials().size());
-        final AllowCredentials allowCredential = assertionChallenge.getAllowCredentials().get(0);
+        final Credential allowCredential = assertionChallenge.getAllowCredentials().get(0);
         assertArrayEquals("credential-1A1*A100CZK".getBytes(), allowCredential.getCredentialId());
         assertEquals("usb", allowCredential.getTransports().get(0));
         assertEquals("public-key", allowCredential.getType());
@@ -194,12 +194,12 @@ class AssertionChallengeConverterTest {
 
         assertNotNull(assertionChallenge.getAllowCredentials());
         assertEquals(2, assertionChallenge.getAllowCredentials().size());
-        final AllowCredentials allowCredential1 = assertionChallenge.getAllowCredentials().get(0);
+        final Credential allowCredential1 = assertionChallenge.getAllowCredentials().get(0);
         assertArrayEquals("credential-1A1*A100CZK".getBytes(), allowCredential1.getCredentialId());
         assertEquals("usb", allowCredential1.getTransports().get(0));
         assertEquals("public-key", allowCredential1.getType());
 
-        final AllowCredentials allowCredential2 = assertionChallenge.getAllowCredentials().get(1);
+        final Credential allowCredential2 = assertionChallenge.getAllowCredentials().get(1);
         assertArrayEquals("credential-2A1*A100CZK".getBytes(), allowCredential2.getCredentialId());
         assertEquals("usb", allowCredential2.getTransports().get(0));
         assertEquals("public-key", allowCredential2.getType());

--- a/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/Fido2AuthenticatorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/Fido2AuthenticatorTest.java
@@ -47,6 +47,7 @@ import com.wultra.security.powerauth.fido2.model.response.RegistrationChallengeR
 import com.wultra.security.powerauth.fido2.model.response.RegistrationResponse;
 import io.getlime.security.powerauth.app.server.Application;
 import io.getlime.security.powerauth.app.server.service.PowerAuthService;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -66,6 +67,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @SpringBootTest(classes = Application.class)
 @ActiveProfiles("test")
+@Transactional
 class Fido2AuthenticatorTest {
 
     private static final String RP_ID = "powerauth.com";


### PR DESCRIPTION

- `RegistrationChallengeResponse` now contains `excludeCredentials`, which is a list of existing credentials.
- `AllowCredentials` data class was renamed to `Credential` to serve both - allowCredential and excludeCredential lists. This has to be reflected on the client side.