### PR TITLE
Fix #1505: Edit scp-deploy workflow to use internal repo

### DIFF
--- a/.github/workflows/scp-deploy.yml
+++ b/.github/workflows/scp-deploy.yml
@@ -19,7 +19,7 @@ jobs:
           cache: maven
       - name: Run Maven Package Step
         run: |
-          mvn -B -U package -Dmaven.test.skip=true
+          mvn -B -U package -Dmaven.test.skip=true -DuseInternalRepo=true
         env:
           INTERNAL_USERNAME: ${{ secrets.JFROG_USERNAME }}
           INTERNAL_PASSWORD: ${{ secrets.JFROG_PASSWORD }}


### PR DESCRIPTION
The scp-deploy workflow fails now because of changes in BC dependencies.