### PR TITLE
Fix #1482: Optimization: Operation expiration optimization

### DIFF
--- a/docs/Configuration-Properties.md
+++ b/docs/Configuration-Properties.md
@@ -83,6 +83,7 @@ Discuss its configuration with the [Spring Boot documentation](https://docs.spri
 | Property                                                                    | Default   | Note                                                                                               |
 |-----------------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------|
 | `powerauth.service.scheduled.job.operationCleanup`                          | `5000`    | Time delay in milliseconds between two consecutive tasks that expire long pending operations.      |
+| `powerauth.service.scheduled.job.expireOperationsLimit`                     | `100`     | Number of long pending operations that will be set expired in single scheduled job run.            |
 | `powerauth.service.scheduled.job.activationsCleanup`                        | `5000`    | Time delay in milliseconds between two consecutive tasks that expire abandoned activations.        |
 | `powerauth.service.scheduled.job.activationsCleanup.lookBackInMilliseconds` | `3600000` | Number of milliseconds to look back in the past when looking for abandoned activations.            |
 | `powerauth.service.scheduled.job.uniqueValueCleanup`                        | `60000`   | Time delay in milliseconds between two consecutive tasks that delete expired unique values.        |

--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -6,6 +6,7 @@ This page contains PowerAuth Server migration instructions.
 When updating across multiple versions, you need to perform all migration steps additively.
 <!-- end -->
 
+- [PowerAuth Server 1.8.0](./PowerAuth-Server-1.8.0.md)
 - [PowerAuth Server 1.7.0](./PowerAuth-Server-1.7.0.md)
 - [PowerAuth Server 1.6.0](./PowerAuth-Server-1.6.0.md)
 - [PowerAuth Server 1.5.0](./PowerAuth-Server-1.5.0.md)

--- a/docs/PowerAuth-Server-1.8.0.md
+++ b/docs/PowerAuth-Server-1.8.0.md
@@ -1,0 +1,18 @@
+# Migration from 1.7.x to 1.8.0
+
+This guide contains instructions for migration from PowerAuth Server version `1.7.x` to version `1.8.0`.
+
+## Database Changes
+
+For convenience, you can use liquibase for your database migration.
+
+For manual changes use SQL scripts:
+
+- [PostgreSQL script](./sql/postgresql/migration_1.7.0_1.8.0.sql)
+- [Oracle script](./sql/oracle/migration_1.7.0_1.8.0.sql)
+- [MSSQL script](./sql/mssql/migration_1.7.0_1.8.0.sql)
+
+### Updated Index on pa_operation Table
+
+Existing database index `pa_operation_status_exp` on the `pa_operation` table was modified to improve performance of the
+process of expiration of pending operations.

--- a/docs/db/changelog/changesets/powerauth-java-server/1.8.x/20240424-index-expire-status.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/1.8.x/20240424-index-expire-status.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <!-- Drop index pa_operation_status_exp -->
+    <changeSet id="1" logicalFilePath="powerauth-java-server/1.8.x/20240424-index-expire-status.xml" author="Jan Pesek">
+        <preConditions onFail="MARK_RAN">
+            <indexExists indexName="pa_operation_status_exp"/>
+        </preConditions>
+        <comment>Drop index on pa_operation(timestamp_expires, status).</comment>
+        <dropIndex tableName="pa_operation" indexName="pa_operation_status_exp" />
+    </changeSet>
+
+    <!-- Create index pa_operation_status_exp with different column ordering -->
+    <changeSet id="2" logicalFilePath="powerauth-java-server/1.8.x/20240424-index-expire-status.xml" author="Jan Pesek">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="pa_operation_status_exp"/>
+            </not>
+        </preConditions>
+        <comment>Create a new index on pa_operation(status, timestamp_expires).</comment>
+        <createIndex tableName="pa_operation" indexName="pa_operation_status_exp">
+            <column name="status" />
+            <column name="timestamp_expires" />
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-java-server/1.8.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/1.8.x/db.changelog-version.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <include file="20240424-index-expire-status.xml" relativeToChangelogFile="true" />
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
@@ -16,5 +16,6 @@
     <include file="1.5.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.6.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.7.x/db.changelog-version.xml" relativeToChangelogFile="true" />
+    <include file="1.8.x/db.changelog-version.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/sql/mssql/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/mssql/migration_1.7.0_1.8.0.sql
@@ -1,0 +1,10 @@
+-- Changeset powerauth-java-server/1.8.x/20240424-index-expire-status.xml::1::Jan Pesek
+-- Drop index on pa_operation(timestamp_expires, status).
+DROP INDEX pa_operation_status_exp ON pa_operation;
+GO
+
+-- Changeset powerauth-java-server/1.8.x/20240424-index-expire-status.xml::2::Jan Pesek
+-- Create a new index on pa_operation(status, timestamp_expires).
+CREATE NONCLUSTERED INDEX pa_operation_status_exp ON pa_operation(status, timestamp_expires);
+GO
+

--- a/docs/sql/oracle/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/oracle/migration_1.7.0_1.8.0.sql
@@ -1,0 +1,8 @@
+-- Changeset powerauth-java-server/1.8.x/20240424-index-expire-status.xml::1::Jan Pesek
+-- Drop index on pa_operation(timestamp_expires, status).
+DROP INDEX pa_operation_status_exp;
+
+-- Changeset powerauth-java-server/1.8.x/20240424-index-expire-status.xml::2::Jan Pesek
+-- Create a new index on pa_operation(status, timestamp_expires).
+CREATE INDEX pa_operation_status_exp ON pa_operation(status, timestamp_expires);
+

--- a/docs/sql/postgresql/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/postgresql/migration_1.7.0_1.8.0.sql
@@ -1,0 +1,8 @@
+-- Changeset powerauth-java-server/1.8.x/20240424-index-expire-status.xml::1::Jan Pesek
+-- Drop index on pa_operation(timestamp_expires, status).
+DROP INDEX pa_operation_status_exp;
+
+-- Changeset powerauth-java-server/1.8.x/20240424-index-expire-status.xml::2::Jan Pesek
+-- Create a new index on pa_operation(status, timestamp_expires).
+CREATE INDEX pa_operation_status_exp ON pa_operation(status, timestamp_expires);
+

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -265,6 +265,12 @@ public class PowerAuthServiceConfiguration {
     private int proximityCheckOtpLength;
 
     /**
+     * Number of operation that will be set expired in the single scheduled job run.
+     */
+    @Value("${powerauth.service.scheduled.job.expireOperationsLimit:100}")
+    private int expireOperationsLimit;
+
+    /**
      * Prepare and configure object mapper.
      * @return Object mapper.
      */

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/OperationRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/OperationRepository.java
@@ -81,8 +81,7 @@ public interface OperationRepository extends CrudRepository<OperationEntity, Str
             SELECT o FROM OperationEntity o 
             WHERE o.timestampExpires < :timestamp
             AND o.status = io.getlime.security.powerauth.app.server.database.model.enumeration.OperationStatusDo.PENDING
-            ORDER BY o.timestampCreated
             """)
-    Stream<OperationEntity> findExpiredPendingOperations(Date timestamp);
+    Stream<OperationEntity> findExpiredPendingOperations(Date timestamp, Pageable pageable);
 
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehavior.java
@@ -328,9 +328,11 @@ public class CallbackUrlBehavior {
         try {
             if (operation != null && operation.getApplications() != null && !operation.getApplications().isEmpty()) {
                 for (ApplicationEntity application : operation.getApplications()) {
-                    final Iterable<CallbackUrlEntity> callbackUrlEntities = callbackUrlRepository.findByApplicationIdAndTypeOrderByName(
-                            application.getId(), CallbackUrlType.OPERATION_STATUS_CHANGE
-                    );
+                    final Iterable<CallbackUrlEntity> callbackUrlEntities = application.getCallbacks()
+                            .stream()
+                            .filter(callbackUrlEntity -> CallbackUrlType.OPERATION_STATUS_CHANGE == callbackUrlEntity.getType())
+                            .toList();
+
                     for (CallbackUrlEntity callbackUrlEntity : callbackUrlEntities) {
                         final Map<String, Object> callbackData = prepareCallbackDataOperation(callbackUrlEntity, operation);
                         notifyCallbackUrl(callbackUrlEntity, callbackData);

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehavior.java
@@ -54,6 +54,7 @@ import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -970,7 +971,9 @@ public class OperationServiceBehavior {
         LockAssert.assertLocked();
         final Date currentTimestamp = new Date();
         logger.debug("Running scheduled task for expiring operations");
-        try (final Stream<OperationEntity> pendingOperations = operationRepository.findExpiredPendingOperations(currentTimestamp)) {
+
+        final PageRequest pageRequest = PageRequest.of(0, powerAuthServiceConfiguration.getExpireOperationsLimit());
+        try (final Stream<OperationEntity> pendingOperations = operationRepository.findExpiredPendingOperations(currentTimestamp, pageRequest)) {
             pendingOperations.forEach(op -> expireOperation(op, currentTimestamp));
         }
     }


### PR DESCRIPTION
Changes:

1. Reordered columns in `pa_operation_status_exp` index: `pa_operation(timestamp_expires, status) -> pa_operation(status, timestamp_expires)`. Now the index is used during the query for expired pending operations.
2. Scheduled job to expire pending operation now sets as expired 100 operations only. This number is configurable via a new property.
3. CallbackUrl entities are no longer fetched via explicit repository call, but via getter on the entity.