### PR TITLE
Fix #1517: FIDO2: Enforce USB transport hint for WAU authenticators

### DIFF
--- a/docs/PowerAuth-Server-1.8.0.md
+++ b/docs/PowerAuth-Server-1.8.0.md
@@ -16,3 +16,11 @@ For manual changes use SQL scripts:
 
 Existing database index `pa_operation_status_exp` on the `pa_operation` table was modified to improve performance of the
 process of expiration of pending operations.
+
+### Add transports Column to pa_fido2_authenticator
+
+A new column `transports` has been added to the `pa_fido2_authenticator` table. The column allows you to assign
+transport hints to a FIDO2 Authenticator registered in the table. These transport hints will be used to build allow
+credential list or exclude credential list during WebAuthn ceremonies, serving as a fallback if the client fails to
+provide transport hints when registering a new credential. The format of the column is a list of authenticator transport
+values supported by the WebAuthn protocol, serialized as a JSON array.

--- a/docs/PowerAuth-Server-1.8.0.md
+++ b/docs/PowerAuth-Server-1.8.0.md
@@ -17,7 +17,7 @@ For manual changes use SQL scripts:
 Existing database index `pa_operation_status_exp` on the `pa_operation` table was modified to improve performance of the
 process of expiration of pending operations.
 
-### Add transports Column to pa_fido2_authenticator
+### Add Transports Column to pa_fido2_authenticator
 
 A new column `transports` has been added to the `pa_fido2_authenticator` table. The column allows you to assign
 transport hints to a FIDO2 Authenticator registered in the table. These transport hints will be used to build allow

--- a/docs/db/changelog/changesets/powerauth-java-server/1.8.x/20240517-fido2-authenticator-transports.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/1.8.x/20240517-fido2-authenticator-transports.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <!-- Add transports column in pa_fido2_authenticator table. -->
+    <changeSet id="1" logicalFilePath="powerauth-java-server/1.8.x/20240517-fido2-authenticator-transports.xml" author="Jan Pesek">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="pa_fido2_authenticator" columnName="transports"/>
+            </not>
+        </preConditions>
+        <comment>Add transports column in pa_fido2_authenticator table.</comment>
+        <addColumn tableName="pa_fido2_authenticator">
+            <column name="transports" type="varchar(255)" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-java-server/1.8.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/1.8.x/db.changelog-version.xml
@@ -5,5 +5,6 @@
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
     <include file="20240424-index-expire-status.xml" relativeToChangelogFile="true" />
+    <include file="20240517-fido2-authenticator-transports.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/sql/mssql/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/mssql/migration_1.7.0_1.8.0.sql
@@ -8,3 +8,8 @@ GO
 CREATE NONCLUSTERED INDEX pa_operation_status_exp ON pa_operation(status, timestamp_expires);
 GO
 
+-- Changeset powerauth-java-server/1.8.x/20240517-fido2-authenticator-transports.xml::1::Jan Pesek
+-- Add transports column in pa_fido2_authenticator table.
+ALTER TABLE pa_fido2_authenticator ADD transports varchar(255);
+GO
+

--- a/docs/sql/oracle/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/oracle/migration_1.7.0_1.8.0.sql
@@ -6,3 +6,7 @@ DROP INDEX pa_operation_status_exp;
 -- Create a new index on pa_operation(status, timestamp_expires).
 CREATE INDEX pa_operation_status_exp ON pa_operation(status, timestamp_expires);
 
+-- Changeset powerauth-java-server/1.8.x/20240517-fido2-authenticator-transports.xml::1::Jan Pesek
+-- Add transports column in pa_fido2_authenticator table.
+ALTER TABLE pa_fido2_authenticator ADD transports VARCHAR2(255);
+

--- a/docs/sql/postgresql/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/postgresql/migration_1.7.0_1.8.0.sql
@@ -6,3 +6,7 @@ DROP INDEX pa_operation_status_exp;
 -- Create a new index on pa_operation(status, timestamp_expires).
 CREATE INDEX pa_operation_status_exp ON pa_operation(status, timestamp_expires);
 
+-- Changeset powerauth-java-server/1.8.x/20240517-fido2-authenticator-transports.xml::1::Jan Pesek
+-- Add transports column in pa_fido2_authenticator table.
+ALTER TABLE pa_fido2_authenticator ADD transports VARCHAR(255);
+

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/database/entity/Fido2AuthenticatorEntity.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/database/entity/Fido2AuthenticatorEntity.java
@@ -18,6 +18,7 @@
 
 package com.wultra.powerauth.fido2.database.entity;
 
+import com.wultra.powerauth.fido2.database.entity.converter.ListToStringConverter;
 import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -27,6 +28,7 @@ import org.springframework.data.util.ProxyUtils;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -52,6 +54,10 @@ public class Fido2AuthenticatorEntity implements Serializable {
     @Enumerated(EnumType.STRING)
     @Column(name = "signature_type", nullable = false)
     private SignatureType signatureType;
+
+    @Convert(converter = ListToStringConverter.class)
+    @Column(name = "transports", columnDefinition = "CLOB")
+    private List<String> transports;
 
     @Override
     public boolean equals(final Object o) {

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/database/entity/converter/ListToStringConverter.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/database/entity/converter/ListToStringConverter.java
@@ -1,0 +1,80 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.powerauth.fido2.database.entity.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Converter between list of strings and JSON serialized storage in a database column.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Converter
+@Component
+@Slf4j
+public class ListToStringConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String EMPTY_LIST = "[]";
+
+    private final ObjectMapper objectMapper;
+
+    public ListToStringConverter(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(final List<String> attributes) {
+        if (CollectionUtils.isEmpty(attributes)) {
+            return EMPTY_LIST;
+        }
+
+        try {
+            return objectMapper.writeValueAsString(attributes);
+        } catch (JsonProcessingException ex) {
+            logger.warn("Conversion failed for attribute list, error: {}", ex.getMessage(), ex);
+            return EMPTY_LIST;
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(final String dbValue) {
+        if (!StringUtils.hasText(dbValue)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return objectMapper.readValue(dbValue, new TypeReference<>() {});
+        } catch (JsonProcessingException ex) {
+            logger.warn("Conversion failed for attribute list, error: {}", ex.getMessage(), ex);
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/RegistrationChallengeConverter.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/RegistrationChallengeConverter.java
@@ -19,21 +19,32 @@
 package com.wultra.powerauth.fido2.rest.model.converter;
 
 import com.wultra.powerauth.fido2.rest.model.entity.RegistrationChallenge;
+import com.wultra.powerauth.fido2.service.Fido2AuthenticatorService;
+import com.wultra.powerauth.fido2.service.model.Fido2Authenticator;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
 import com.wultra.security.powerauth.fido2.model.entity.Credential;
 import com.wultra.security.powerauth.fido2.model.response.RegistrationChallengeResponse;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /**
+ * Converter for registration challenge values.
+ *
  * @author Petr Dvorak, petr@wultra.com
  */
 @Component
+@AllArgsConstructor
 @Slf4j
 public class RegistrationChallengeConverter {
+
+    private final Fido2AuthenticatorService fido2AuthenticatorService;
 
     /**
      * Convert a new assertion challenge response from a provided challenge.
@@ -54,11 +65,17 @@ public class RegistrationChallengeConverter {
         return destination;
     }
 
-    public static Credential toCredentialDescriptor(final AuthenticatorDetail authenticatorDetail) {
+    public Credential toCredentialDescriptor(final AuthenticatorDetail authenticatorDetail) {
         @SuppressWarnings("unchecked")
-        final List<String> transports = (List<String>) authenticatorDetail.getExtras().get("transports");
-        final byte[] credentialId = Base64.getDecoder().decode(authenticatorDetail.getCredentialId());
+        List<String> transports = (List<String>) authenticatorDetail.getExtras().get("transports");
 
+        if (CollectionUtils.isEmpty(transports)) {
+            final String aaguid = (String) authenticatorDetail.getExtras().get("aaguid");
+            final Fido2Authenticator model = fido2AuthenticatorService.findByAaguid(UUID.fromString(aaguid));
+            transports = CollectionUtils.isEmpty(model.transports()) ? Collections.emptyList() : model.transports();
+        }
+
+        final byte[] credentialId = Base64.getDecoder().decode(authenticatorDetail.getCredentialId());
         return Credential.builder()
                 .credentialId(credentialId)
                 .transports(transports)

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/Fido2AuthenticatorService.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/Fido2AuthenticatorService.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -76,15 +77,15 @@ public class Fido2AuthenticatorService {
     }
 
     private static Fido2Authenticator convert(final Fido2AuthenticatorEntity entity) {
-        return new Fido2Authenticator(UUID.fromString(entity.getAaguid()), entity.getDescription(), entity.getSignatureType());
+        return new Fido2Authenticator(UUID.fromString(entity.getAaguid()), entity.getDescription(), entity.getSignatureType(), entity.getTransports());
     }
 
     private static Fido2Authenticator unknownAuthenticator() {
-        return new Fido2Authenticator(null, UNKNOWN_AUTHENTICATOR_DESCRIPTION, UNKNOWN_AUTHENTICATOR_SIGNATURE_TYPE);
+        return new Fido2Authenticator(null, UNKNOWN_AUTHENTICATOR_DESCRIPTION, UNKNOWN_AUTHENTICATOR_SIGNATURE_TYPE, Collections.emptyList());
     }
 
     private static Fido2Authenticator unknownAuthenticator(final UUID aaguid) {
-        return new Fido2Authenticator(aaguid, UNKNOWN_AUTHENTICATOR_DESCRIPTION, UNKNOWN_AUTHENTICATOR_SIGNATURE_TYPE);
+        return new Fido2Authenticator(aaguid, UNKNOWN_AUTHENTICATOR_DESCRIPTION, UNKNOWN_AUTHENTICATOR_SIGNATURE_TYPE, Collections.emptyList());
     }
 
 }

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/model/Fido2Authenticator.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/model/Fido2Authenticator.java
@@ -20,6 +20,8 @@ package com.wultra.powerauth.fido2.service.model;
 
 import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -32,15 +34,20 @@ import java.util.UUID;
 public record Fido2Authenticator(
         UUID aaguid,
         String description,
-        SignatureType signatureType
+        SignatureType signatureType,
+        List<String> transports
 ) {
 
     public static Fido2Authenticator create(String aaguid, String description) {
-        return new Fido2Authenticator(UUID.fromString(aaguid), description, SignatureType.POSSESSION);
+        return new Fido2Authenticator(UUID.fromString(aaguid), description, SignatureType.POSSESSION, Collections.emptyList());
     }
 
     public static Fido2Authenticator create(String aaguid, String description, SignatureType signatureType) {
-        return new Fido2Authenticator(UUID.fromString(aaguid), description, signatureType);
+        return new Fido2Authenticator(UUID.fromString(aaguid), description, signatureType, Collections.emptyList());
+    }
+
+    public static Fido2Authenticator create(String aaguid, String description, SignatureType signatureType, List<String> transports) {
+        return new Fido2Authenticator(UUID.fromString(aaguid), description, signatureType, transports);
     }
 
     @Override

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/model/Fido2DefaultAuthenticators.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/model/Fido2DefaultAuthenticators.java
@@ -20,10 +20,7 @@ package com.wultra.powerauth.fido2.service.model;
 
 import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -165,7 +162,7 @@ public class Fido2DefaultAuthenticators {
             Fido2Authenticator.create("504d7149-4e4c-3841-4555-55445a677357", "WiSECURE AuthTron USB FIDO2 Authenticator"),
 
             // Wultra
-            Fido2Authenticator.create("dca09ba7-4992-4be8-9283-ee98cd6fb529", "Wultra Authenticator 1", SignatureType.POSSESSION_KNOWLEDGE),
+            Fido2Authenticator.create("dca09ba7-4992-4be8-9283-ee98cd6fb529", "Wultra Authenticator 1", SignatureType.POSSESSION_KNOWLEDGE, List.of("usb")),
 
             // Yubico
             Fido2Authenticator.create("0bb43545-fd2c-4185-87dd-feb0b2916ace", "Security Key NFC by Yubico - Enterprise Edition"),

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/RegistrationChallengeConverterTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/RegistrationChallengeConverterTest.java
@@ -1,0 +1,117 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.powerauth.fido2.rest.model.converter;
+
+import com.wultra.powerauth.fido2.service.Fido2AuthenticatorService;
+import com.wultra.powerauth.fido2.service.model.Fido2Authenticator;
+import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
+import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
+import com.wultra.security.powerauth.fido2.model.entity.Credential;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test of {@link RegistrationChallengeConverter}.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@ExtendWith(MockitoExtension.class)
+class RegistrationChallengeConverterTest {
+
+    @Mock
+    private Fido2AuthenticatorService fido2AuthenticatorService;
+
+    @InjectMocks
+    private RegistrationChallengeConverter tested;
+
+    @Test
+    void testToCredentialDescriptor() {
+        final AuthenticatorDetail authenticatorDetail = new AuthenticatorDetail();
+        authenticatorDetail.setCredentialId(Base64.getEncoder().encodeToString("credential-1".getBytes()));
+        authenticatorDetail.setExtras(Map.of(
+                "transports", List.of("hybrid"),
+                "aaguid", "10000000-0000-0000-0000-000000000000"));
+
+        final Credential excludeCredential = tested.toCredentialDescriptor(authenticatorDetail);
+        assertArrayEquals("credential-1".getBytes(), excludeCredential.getCredentialId());
+        assertEquals(1, excludeCredential.getTransports().size());
+        assertEquals("hybrid", excludeCredential.getTransports().get(0));
+        assertEquals("public-key", excludeCredential.getType());
+    }
+
+    @Test
+    void testToCredentialDescriptor_emptyTransports() {
+        final AuthenticatorDetail authenticatorDetail = new AuthenticatorDetail();
+        authenticatorDetail.setCredentialId(Base64.getEncoder().encodeToString("credential-1".getBytes()));
+        authenticatorDetail.setExtras(Map.of(
+                "transports", Collections.emptyList(),
+                "aaguid", "10000000-0000-0000-0000-000000000000"));
+
+        when(fido2AuthenticatorService.findByAaguid(UUID.fromString("10000000-0000-0000-0000-000000000000")))
+                .thenReturn(Fido2Authenticator.create("10000000-0000-0000-0000-000000000000", "Any", SignatureType.POSSESSION, List.of("usb")));
+
+        final Credential excludeCredential = tested.toCredentialDescriptor(authenticatorDetail);
+        assertArrayEquals("credential-1".getBytes(), excludeCredential.getCredentialId());
+        assertEquals(1, excludeCredential.getTransports().size());
+        assertEquals("usb", excludeCredential.getTransports().get(0));
+        assertEquals("public-key", excludeCredential.getType());
+    }
+
+    @Test
+    void testToCredentialDescriptor_nullTransports() {
+        final AuthenticatorDetail authenticatorDetail = new AuthenticatorDetail();
+        authenticatorDetail.setCredentialId(Base64.getEncoder().encodeToString("credential-1".getBytes()));
+        authenticatorDetail.setExtras(Map.of(
+                "aaguid", "10000000-0000-0000-0000-000000000000"));
+
+        when(fido2AuthenticatorService.findByAaguid(UUID.fromString("10000000-0000-0000-0000-000000000000")))
+                .thenReturn(Fido2Authenticator.create("10000000-0000-0000-0000-000000000000", "Any", SignatureType.POSSESSION, List.of("usb")));
+
+        final Credential excludeCredential = tested.toCredentialDescriptor(authenticatorDetail);
+        assertArrayEquals("credential-1".getBytes(), excludeCredential.getCredentialId());
+        assertEquals(1, excludeCredential.getTransports().size());
+        assertEquals("usb", excludeCredential.getTransports().get(0));
+        assertEquals("public-key", excludeCredential.getType());
+    }
+
+    @Test
+    void testToCredentialDescriptor_bothTransportsEmpty() {
+        final AuthenticatorDetail authenticatorDetail = new AuthenticatorDetail();
+        authenticatorDetail.setCredentialId(Base64.getEncoder().encodeToString("credential-1".getBytes()));
+        authenticatorDetail.setExtras(Map.of(
+                "aaguid", "10000000-0000-0000-0000-000000000000"));
+
+        when(fido2AuthenticatorService.findByAaguid(UUID.fromString("10000000-0000-0000-0000-000000000000")))
+                .thenReturn(Fido2Authenticator.create("10000000-0000-0000-0000-000000000000", "Any", SignatureType.POSSESSION, null));
+
+        final Credential excludeCredential = tested.toCredentialDescriptor(authenticatorDetail);
+        assertArrayEquals("credential-1".getBytes(), excludeCredential.getCredentialId());
+        assertEquals(0, excludeCredential.getTransports().size());
+    }
+
+}

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/service/Fido2AuthenticatorServiceTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/service/Fido2AuthenticatorServiceTest.java
@@ -28,6 +28,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -78,6 +80,7 @@ class Fido2AuthenticatorServiceTest {
         assertEquals(aaguid, authenticator.aaguid());
         assertEquals("Wultra Authenticator 1", authenticator.description());
         assertEquals(SignatureType.POSSESSION_KNOWLEDGE, authenticator.signatureType());
+        assertEquals(List.of("usb"), authenticator.transports());
     }
 
     @Test
@@ -90,6 +93,7 @@ class Fido2AuthenticatorServiceTest {
         assertEquals(aaguid, authenticator.aaguid());
         assertEquals("Unknown FIDO2 Authenticator", authenticator.description());
         assertEquals(SignatureType.POSSESSION, authenticator.signatureType());
+        assertEquals(Collections.emptyList(), authenticator.transports());
     }
 
     @Test
@@ -98,6 +102,7 @@ class Fido2AuthenticatorServiceTest {
         assertNull(authenticator.aaguid());
         assertEquals("Unknown FIDO2 Authenticator", authenticator.description());
         assertEquals(SignatureType.POSSESSION, authenticator.signatureType());
+        assertEquals(Collections.emptyList(), authenticator.transports());
     }
 
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
@@ -77,14 +77,16 @@ public class PowerAuthAssertionProvider implements AssertionProvider {
     private final AuditingServiceBehavior audit;
     private final PowerAuthAuthenticatorProvider authenticatorProvider;
     private final Fido2AuthenticatorService fido2AuthenticatorService;
+    private final AssertionChallengeConverter assertionChallengeConverter;
 
     @Autowired
-    public PowerAuthAssertionProvider(ServiceBehaviorCatalogue serviceBehaviorCatalogue, RepositoryCatalogue repositoryCatalogue, AuditingServiceBehavior audit, PowerAuthAuthenticatorProvider authenticatorProvider, Fido2AuthenticatorService fido2AuthenticatorService) {
+    public PowerAuthAssertionProvider(ServiceBehaviorCatalogue serviceBehaviorCatalogue, RepositoryCatalogue repositoryCatalogue, AuditingServiceBehavior audit, PowerAuthAuthenticatorProvider authenticatorProvider, Fido2AuthenticatorService fido2AuthenticatorService, final AssertionChallengeConverter assertionChallengeConverter) {
         this.serviceBehaviorCatalogue = serviceBehaviorCatalogue;
         this.repositoryCatalogue = repositoryCatalogue;
         this.audit = audit;
         this.authenticatorProvider = authenticatorProvider;
         this.fido2AuthenticatorService = fido2AuthenticatorService;
+        this.assertionChallengeConverter = assertionChallengeConverter;
     }
 
     @Override
@@ -104,7 +106,7 @@ public class PowerAuthAssertionProvider implements AssertionProvider {
 
         final OperationCreateRequest operationCreateRequest = AssertionChallengeConverter.convertAssertionRequestToOperationRequest(request, authenticatorDetails);
         final OperationDetailResponse operationDetailResponse = serviceBehaviorCatalogue.getOperationBehavior().createOperation(operationCreateRequest);
-        return AssertionChallengeConverter.convertAssertionChallengeFromOperationDetail(operationDetailResponse, authenticatorDetails);
+        return assertionChallengeConverter.convertAssertionChallengeFromOperationDetail(operationDetailResponse, authenticatorDetails);
     }
 
     @Override

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthRegistrationProvider.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthRegistrationProvider.java
@@ -61,13 +61,15 @@ public class PowerAuthRegistrationProvider implements RegistrationProvider {
     private final RepositoryCatalogue repositoryCatalogue;
     private final ServiceBehaviorCatalogue serviceBehaviorCatalogue;
     private final PowerAuthAuthenticatorProvider authenticatorProvider;
+    private final RegistrationChallengeConverter registrationChallengeConverter;
     private final KeyConvertor keyConvertor = new KeyConvertor();
 
     @Autowired
-    public PowerAuthRegistrationProvider(final RepositoryCatalogue repositoryCatalogue, final ServiceBehaviorCatalogue serviceBehaviorCatalogue, final PowerAuthAuthenticatorProvider authenticatorProvider) {
+    public PowerAuthRegistrationProvider(final RepositoryCatalogue repositoryCatalogue, final ServiceBehaviorCatalogue serviceBehaviorCatalogue, final PowerAuthAuthenticatorProvider authenticatorProvider, final RegistrationChallengeConverter registrationChallengeConverter) {
         this.repositoryCatalogue = repositoryCatalogue;
         this.serviceBehaviorCatalogue = serviceBehaviorCatalogue;
         this.authenticatorProvider = authenticatorProvider;
+        this.registrationChallengeConverter = registrationChallengeConverter;
     }
 
     @Override
@@ -78,7 +80,7 @@ public class PowerAuthRegistrationProvider implements RegistrationProvider {
 
         final List<Credential> excludeCredentials = authenticatorProvider.findByUserId(userId, applicationId)
                 .stream()
-                .map(RegistrationChallengeConverter::toCredentialDescriptor)
+                .map(registrationChallengeConverter::toCredentialDescriptor)
                 .toList();
 
         final RegistrationChallenge registrationChallenge = new RegistrationChallenge();


### PR DESCRIPTION
A new column `transports` has been added to the `pa_fido2_authenticator` table, which values is used during the allow/exclude credential list build as a fallback in case a browser failed to provide transport hints during the registration ceremony.

Effect on **non-Wultra authenticators**:
- If the DB column is not set or contains empty list, there is no behaviour changes compared to the current version.
- If the DB column contains non-empty list, the list will be used in case a browser did not provide transport hints during the registration ceremony.

Effect on **Wultra authenticator**:
- If the DB column for WAU record is not set or contains empty list, `["usb"]` will be used in case a browser did not provide transport hints during the registration ceremony.
- If the DB column for WAU record is non-empty list, the assigned list will be used in case a browser did not provide transport hints during the registration ceremony.

**The column `transports` is ignored in case a browser provided a relevant transport hints.**