### PR TITLE
Fix #1529: FIDO2: Missing external ID in activation (backport)

### DIFF
--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverter.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/AssertionChallengeConverter.java
@@ -79,6 +79,7 @@ public class AssertionChallengeConverter {
         destination.setUserId(source.getUserId());
         destination.setApplications(source.getApplicationIds());
         destination.setTemplateName(source.getTemplateName());
+        destination.setExternalId(source.getExternalId());
         destination.getParameters().putAll(source.getParameters());
 
         //TODO: Use relation to activation ID instead of additional data


### PR DESCRIPTION
(cherry picked from commit d66f88fb297aa504b235c22ca5131f814956ea4b)