### PR TITLE
Fix #1560: Create Operation does not return proximity OTP (backport)

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehavior.java
@@ -240,7 +240,7 @@ public class OperationServiceBehavior {
 
         final OperationEntity savedEntity = operationRepository.save(operationEntity);
         behavior.getCallbackUrlBehavior().notifyCallbackListenersOnOperationChange(savedEntity);
-        return convertFromEntity(savedEntity);
+        return convertFromEntityAndFillOtp(savedEntity);
 
     }
 
@@ -622,9 +622,9 @@ public class OperationServiceBehavior {
                 claimOperation(operationOptional.get(), userId, currentTimestamp),
                 currentTimestamp
         );
-        final OperationDetailResponse operationDetailResponse = convertFromEntity(operationEntity);
+        final OperationDetailResponse operationDetailResponse = convertFromEntityAndFillOtp(operationEntity);
         extendAndSetOperationDetailData(operationDetailResponse);
-        generateAndSetOtpToOperationDetail(operationEntity, operationDetailResponse);
+
         return operationDetailResponse;
     }
 
@@ -675,8 +675,8 @@ public class OperationServiceBehavior {
                 final OperationEntity operationEntity = expireOperation(op, currentTimestamp);
                 // Skip operation that just expired
                 if (OperationStatusDo.PENDING.equals(operationEntity.getStatus())) {
-                    final OperationDetailResponse operationDetail = convertFromEntity(operationEntity);
-                    generateAndSetOtpToOperationDetail(operationEntity, operationDetail);
+                    final OperationDetailResponse operationDetail = convertFromEntityAndFillOtp(operationEntity);
+
                     result.add(operationDetail);
                 }
             });
@@ -712,6 +712,14 @@ public class OperationServiceBehavior {
         return result;
     }
 
+    /**
+     * Convert the given entity to the response class.
+     * Mind that it does not fill the proximity OTP. If you need so, use {@link #convertFromEntityAndFillOtp(OperationEntity)} instead.
+     *
+     * @param source Entity to convert.
+     * @return response class
+     * @see #convertFromEntityAndFillOtp(OperationEntity)
+     */
     private OperationDetailResponse convertFromEntity(OperationEntity source) {
         final OperationDetailResponse destination = new OperationDetailResponse();
         destination.setId(source.getId());
@@ -828,10 +836,20 @@ public class OperationServiceBehavior {
         return m3;
     }
 
+    /**
+     * Convert the given entity to the response class.
+     * Unlike {@link #convertFromEntity(OperationEntity)} also fill proximity OTP value if needed.
+     *
+     * @param source Entity to convert.
+     * @return response class
+     * @see #convertFromEntity(OperationEntity)
+     */
     @SneakyThrows(GenericServiceException.class)
-    private void generateAndSetOtpToOperationDetail(final OperationEntity operation, final OperationDetailResponse operationDetailResponse) {
-        final String totp = generateTotp(operation, powerAuthServiceConfiguration.getProximityCheckOtpLength());
-        operationDetailResponse.setProximityOtp(totp);
+    private OperationDetailResponse convertFromEntityAndFillOtp(final OperationEntity source) {
+        final String totp = generateTotp(source, powerAuthServiceConfiguration.getProximityCheckOtpLength());
+        final OperationDetailResponse target = convertFromEntity(source);
+        target.setProximityOtp(totp);
+        return target;
     }
 
     private String generateTotp(final OperationEntity operation, final int otpLength) throws GenericServiceException {
@@ -844,9 +862,9 @@ public class OperationServiceBehavior {
         }
 
         try {
-            byte[] seedBytes = Base64.getDecoder().decode(seed);
+            final byte[] seedBytes = Base64.getDecoder().decode(seed);
             final Instant now = Instant.now();
-            byte[] totp = Totp.generateTotpSha256(seedBytes, now, otpLength);
+            final byte[] totp = Totp.generateTotpSha256(seedBytes, now, otpLength);
 
             return new String(totp, StandardCharsets.UTF_8);
         } catch (CryptoProviderException | IllegalArgumentException e) {

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehaviorTest.java
@@ -85,9 +85,51 @@ class OperationServiceBehaviorTest {
         request.setUserId("test-user");
 
         final OperationDetailResponse operationDetailResponse = operationService.createOperation(request);
-        final OperationEntity savedEntity = operationRepository.findOperation(operationDetailResponse.getId()).get();
-        assertTrue(operationRepository.findOperation(operationDetailResponse.getId()).isPresent());
-        assertEquals("testActivationId", savedEntity.getActivationId());
+        final Optional<OperationEntity> savedEntity = operationRepository.findOperation(operationDetailResponse.getId());
+
+        assertTrue(savedEntity.isPresent());
+        assertEquals("testActivationId", savedEntity.get().getActivationId());
+        assertNull(operationDetailResponse.getProximityOtp());
+    }
+
+    @Test
+    void testCreateOperationWithoutActivationIdAndExplicitProximityCheck() throws Exception {
+        final OperationCreateRequest request = new OperationCreateRequest();
+        request.setTemplateName("test-template");
+        request.setApplications(List.of(APP_ID));
+        request.setUserId("test-user");
+        request.setProximityCheckEnabled(true);
+
+        final OperationDetailResponse operationDetailResponse = operationService.createOperation(request);
+        assertNotNull(operationDetailResponse.getProximityOtp());
+
+        final OperationDetailRequest detailRequest = new OperationDetailRequest();
+        detailRequest.setOperationId(operationDetailResponse.getId());
+
+        final OperationDetailResponse operationDetail = operationService.getOperation(detailRequest);
+        assertNotNull(operationDetail);
+        assertNotNull(operationDetail.getProximityOtp());
+        assertNull(operationDetail.getActivationId());
+    }
+
+    @Test
+    void testCreateOperationWithoutActivationIdAndImplicitProximityCheck() throws Exception {
+        final OperationCreateRequest request = new OperationCreateRequest();
+        request.setTemplateName("test-template-proximity-check");
+        request.setApplications(List.of(APP_ID));
+        request.setUserId("test-user");
+
+        final OperationDetailResponse operationDetailResponse = operationService.createOperation(request);
+        assertNotNull(operationDetailResponse.getProximityOtp());
+
+        final OperationDetailRequest detailRequest = new OperationDetailRequest();
+        detailRequest.setOperationId(operationDetailResponse.getId());
+
+        final OperationDetailResponse operationDetail = operationService.getOperation
+                (detailRequest);
+        assertNotNull(operationDetail);
+        assertNotNull(operationDetail.getProximityOtp());
+        assertNull(operationDetail.getActivationId());
     }
 
     /**

--- a/powerauth-java-server/src/test/resources/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehaviorTest.sql
+++ b/powerauth-java-server/src/test/resources/io/getlime/security/powerauth/app/server/service/behavior/tasks/OperationServiceBehaviorTest.sql
@@ -1,5 +1,6 @@
-INSERT INTO pa_operation_template (id, template_name, operation_type, data_template, signature_type, max_failure_count, expiration, proximity_check_enabled)
-VALUES (100, 'test-template', 'test-template', 'A2', 'POSSESSION_KNOWLEDGE', 5, 300, false);
+INSERT INTO pa_operation_template (id, template_name, operation_type, data_template, signature_type, max_failure_count, expiration, proximity_check_enabled) VALUES
+    (100, 'test-template', 'test-template', 'A2', 'POSSESSION_KNOWLEDGE', 5, 300, false),
+    (101, 'test-template-proximity-check', 'test-template', 'A2', 'POSSESSION_KNOWLEDGE', 5, 300, true);
 
 INSERT INTO pa_application (id, name) VALUES
     (21, 'PA_Tests');


### PR DESCRIPTION
* Fix #1560: Create Operation does not return proximity OTP

Co-authored-by: Zdeněk Černý <zdenek.cerny@wultra.com>
(cherry picked from commit e17f6f6139b7a08824279514bc98743dfc87e7d7)