### PR TITLE
Increase defaultLockAtMostFor to 60m

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/Application.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/Application.java
@@ -37,7 +37,7 @@ import java.security.Security;
 @SpringBootApplication
 @EnableScheduling
 @EnableCaching
-@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+@EnableSchedulerLock(defaultLockAtMostFor = "60m")
 @ConfigurationPropertiesScan
 @EnableJpaRepositories(basePackages = {"io.getlime.security.powerauth.app.server", "com.wultra.powerauth.fido2"})
 @EntityScan(basePackages = {"io.getlime.security.powerauth.app.server", "com.wultra.powerauth.fido2"})


### PR DESCRIPTION
It fixes error: lockAtLeastFor is longer than lockAtMostFor for lock 'evictFido2AuthenticatorCacheTask'

A follow-up to #1532