### PR TITLE
Remove scheduler lock from Fido2CleaningTask

### DIFF
--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/task/Fido2CleaningTask.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/task/Fido2CleaningTask.java
@@ -22,8 +22,6 @@ package com.wultra.powerauth.fido2.task;
 import com.wultra.powerauth.fido2.service.CacheService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockAssert;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -40,11 +38,7 @@ public class Fido2CleaningTask {
     private final CacheService cacheService;
 
     @Scheduled(fixedRateString = "${powerauth.service.scheduled.job.fido2AuthenticatorCacheEviction:3600000}")
-    @SchedulerLock(
-            name = "evictFido2AuthenticatorCacheTask",
-            lockAtLeastFor = "#{T(java.lang.Math).round(${powerauth.service.scheduled.job.fido2AuthenticatorCacheEviction:3600000} * 0.8)}")
     public void evictFido2AuthenticatorCache() {
-        LockAssert.assertLocked();
         logger.debug("evictFido2AuthenticatorCache");
         cacheService.evictFido2AuthenticatorCache();
     }


### PR DESCRIPTION
It fixes the error: `lockAtLeastFor is longer than lockAtMostFor for lock 'evictFido2AuthenticatorCacheTask'`
Cleaning local cache, no need to lock the job across the whole cluster.

A follow-up to #1532