### PR TITLE
Fix #1644: Investigate error on Base64 decoding in challenge

### DIFF
--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/Base64UrlToStringDeserializer.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/Base64UrlToStringDeserializer.java
@@ -34,7 +34,7 @@ import java.util.Base64;
  * @author Petr Dvorak, petr@wultra.com
  */
 @Slf4j
-public class Base64ToStringDeserializer extends StdDeserializer<String> {
+public class Base64UrlToStringDeserializer extends StdDeserializer<String> {
 
     @Serial
     private static final long serialVersionUID = 2540966716709142276L;
@@ -42,7 +42,7 @@ public class Base64ToStringDeserializer extends StdDeserializer<String> {
     /**
      * No-arg deserializer constructor.
      */
-    public Base64ToStringDeserializer() {
+    public Base64UrlToStringDeserializer() {
         this(null);
     }
 
@@ -50,12 +50,12 @@ public class Base64ToStringDeserializer extends StdDeserializer<String> {
      * Deserializer constructor with value class parameter.
      * @param vc Value class.
      */
-    public Base64ToStringDeserializer(Class<?> vc) {
+    public Base64UrlToStringDeserializer(Class<?> vc) {
         super(vc);
     }
 
     /**
-     * Deserialize data from Base64 to string.
+     * Deserialize data from Base64Url to string.
      * @param jsonParser JSON parser.
      * @param deserializationContext Deserialization context.
      * @return Deserialized string.
@@ -64,7 +64,7 @@ public class Base64ToStringDeserializer extends StdDeserializer<String> {
     @Override
     public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws Fido2DeserializationException {
         try {
-            return new String(Base64.getDecoder().decode(jsonParser.getText()), StandardCharsets.UTF_8);
+            return new String(Base64.getUrlDecoder().decode(jsonParser.getText()), StandardCharsets.UTF_8);
         }  catch (IOException e) {
             logger.debug(e.getMessage(), e);
             throw new Fido2DeserializationException(e.getMessage(), e);

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/CollectedClientData.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/rest/model/entity/CollectedClientData.java
@@ -20,7 +20,7 @@ package com.wultra.powerauth.fido2.rest.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.wultra.powerauth.fido2.rest.model.converter.serialization.Base64ToStringDeserializer;
+import com.wultra.powerauth.fido2.rest.model.converter.serialization.Base64UrlToStringDeserializer;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
@@ -38,7 +38,7 @@ public class CollectedClientData {
     @NotBlank
     private String type;
     @NotEmpty
-    @JsonDeserialize(using = Base64ToStringDeserializer.class)
+    @JsonDeserialize(using = Base64UrlToStringDeserializer.class)
     private String challenge;
     @NotBlank
     private String origin;

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/CollectedClientDataDeserializerTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/CollectedClientDataDeserializerTest.java
@@ -43,4 +43,18 @@ class CollectedClientDataDeserializerTest {
         assertFalse(result.isCrossOrigin());
     }
 
+    @Test
+    void testDeserialize_specialSymbolsInChallenge() throws Exception {
+        final CollectedClientData result = CollectedClientDataDeserializer.deserialize("eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTnpCaE9UY3labUV0TWpBd1lTMDBOVEZpTFdFM1lUY3RObVZqTVRNM01qTXdNV05oSmtFeEtrRXlNVU5hU3lwSmRHVjRkREhGdm14MUlIUmxlSFIxZHNTYjhKLU5sQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MyIsImNyb3NzT3JpZ2luIjpmYWxzZX0=");
+
+        assertEquals("""
+                {"type":"webauthn.get","challenge":"NzBhOTcyZmEtMjAwYS00NTFiLWE3YTctNmVjMTM3MjMwMWNhJkExKkEyMUNaSypJdGV4dDHFvmx1IHRleHR1dsSb8J-NlA","origin":"http://localhost:8083","crossOrigin":false}
+                """.strip(), result.getEncoded());
+        assertEquals("webauthn.get", result.getType());
+        assertEquals("70a972fa-200a-451b-a7a7-6ec1372301ca&A1*A21CZK*Itext1žlu textuvě\uD83C\uDF54", result.getChallenge());
+        assertEquals("http://localhost:8083", result.getOrigin());
+        assertNull(result.getTopOrigin());
+        assertFalse(result.isCrossOrigin());
+    }
+
 }


### PR DESCRIPTION
Challenge is encoded to Base64Url on the browser level. The encoded challenge is then encapsulated to the [Collected Client Data structure](https://www.w3.org/TR/webauthn-3/#dictionary-client-data), which hash is later signed by the authenticator. Base64Url decoding should be applied on the challenge during the CollectedClientData deserialization.