### PR TITLE
Limit client-model dependency from starter-validation to hibernate-validator

### DIFF
--- a/powerauth-client-model/pom.xml
+++ b/powerauth-client-model/pom.xml
@@ -41,8 +41,8 @@
             <artifactId>spring-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Limit client-model dependency from starter-validation to hibernate-validator only to avoid tomcat-embed-el transient dependency.

A follow-up to #1679