### PR TITLE
Fix #1722: Fix CallbackUrlBehaviorTest

### DIFF
--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/CallbackUrlBehaviorTest.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.app.server.service.callbacks.CallbackUrlEve
 import io.getlime.security.powerauth.app.server.service.callbacks.model.CallbackUrlConvertor;
 import io.getlime.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import io.getlime.security.powerauth.app.server.service.model.ServiceError;
+import io.getlime.security.powerauth.app.server.task.CleaningTask;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,12 @@ class CallbackUrlBehaviorTest {
 
     @MockBean
     private CallbackUrlEventService callbackUrlEventService;
+
+    /**
+     * Mock CleaningTask to avoid running scheduled job when mocking CallbackUrlEventService
+     */
+    @MockBean
+    private CleaningTask cleaningTask;
 
     @Test
     void testCreateCallbackUrl() throws Exception {


### PR DESCRIPTION
After merging https://github.com/wultra/powerauth-server/pull/1728 a test failure occured in `CallbackUrlBehaviorTest`.

Some test from `CallbackUrlBehaviorTest` could fail because of background scheduled task are calling mocked `CallbackUrlEventService`. Avoid running the scheduled task by mocking also the `CleaningTask`